### PR TITLE
Rubygems require fix

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -1,6 +1,7 @@
 require "builder"
 require 'sinatra/base'
 require 'rubygems'
+require 'rubygems/builder'
 require "rubygems/indexer"
 
 require 'hostess'


### PR DESCRIPTION
Hi cwninja,

tried a fresh install of geminabox under Ruby 1.9.2 / Rubygems 1.3.x / Passenger 3 and worked my way through some consecutive errors which in the end made me update Rubygems to version 1.5.0 and change one line in geminabox.rb. I'm sorry if this is not one of the more verbose bug reports...

Cheers
Klaus
