### PR TITLE
GemVersionCollection explodes if given [nil,nil,nil] gemdef

### DIFF
--- a/lib/geminabox/gem_version_collection.rb
+++ b/lib/geminabox/gem_version_collection.rb
@@ -8,6 +8,7 @@ class Geminabox::GemVersionCollection
 
   def <<(gemdef)
     name,version,_ = gemdef
+    return self if name.nil?
     @gems[name] += [version].flatten
     @gems[name].sort!
     self


### PR DESCRIPTION
Protect GemVersionCollection from exploding due to [nil,nil,nil] being un-marshalled from specs.4.8.gz

I've noticed on Rubygems 1.7.2 on FreeBSD when Geminabox reindexes the gems after receiving a new gem that an Internal Error is raised due to a NoMethodError - undefined method `<=>' for nil:NilClass when calling sort!

As far as I could tell this was due to the presence of [nil,nil,nil] in the specs un-marshalled data.

I'm not entirely sure why these get into the index in the first place. Running gem generate in the data directory fixes the issue but running the Gem::Indexer.new(data_dir).generate_index method as per the #reindex method causes the problem to return.
