### PR TITLE
Added and documented configuration for disabling RubyGems' legacy index support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,11 @@ Create a config.ru as follows:
 
 And finally, hook up the config.ru as you normally would ([passenger][passenger], [thin][thin], [unicorn][unicorn], whatever floats your boat).
 
+## Legacy RubyGems index
+
+RubyGems supports generating indexes for the so called legacy verions (< 1.2), and since it is very rare to use such versions nowadays, it can be disabled, thus improving indexing times for large repositories. If it's safe for your application, you can disable support for these legacy versions by adding the following configuration to yout config.ru file:
+
+    Geminabox.build_legacy = false
 
 ## Client Usage
 

--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -14,6 +14,7 @@ class Geminabox < Sinatra::Base
 
   set :public_folder, File.join(File.dirname(__FILE__), *%w[.. public])
   set :data, File.join(File.dirname(__FILE__), *%w[.. data])
+  set :build_legacy, true
   set :views, File.join(File.dirname(__FILE__), *%w[.. views])
   set :allow_replace, false
   use Hostess
@@ -109,7 +110,11 @@ HTML
 
   def reindex
     Geminabox.fixup_bundler_rubygems!
-    Gem::Indexer.new(settings.data).generate_index
+    indexer.generate_index
+  end
+
+  def indexer
+    Gem::Indexer.new(settings.data, :build_legacy => settings.build_legacy)
   end
 
   def file_path


### PR DESCRIPTION
We have a quite large installation of Geminabox, and disabling build_legacy improved our push time from ~20s to ~8s.
