### PR TITLE
Fix gem versions range output

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -7,7 +7,7 @@
 
     <% @gems.by_name do |name, versions| %>
       <li <%= %{id="jump_#{name[0..0]}"} if @index_gems.delete(name[0..0]) %> class="gem-version">
-        <h2><%= name %> (<%= versions.count == 1 ? versions.first.number : "#{versions.first.number} - #{versions.first.number}" %>)</h2>
+        <h2><%= name %> (<%= versions.count == 1 ? versions.first.number : "#{versions.first.number} - #{versions.last.number}" %>)</h2>
         <% versions.each do |version| %>
           <p>
             <code>gem install <%= version.name %> <%= "--prerelease" if version.number.to_s.match(/[a-z]/i) %> -v "<%= version.number %>"</code>


### PR DESCRIPTION
Currently it displays "first_version - first_version", instead of "first_version - last_version"
