### PR TITLE
Use URI.join for "/update" appending

### DIFF
--- a/lib/rubygems/commands/inabox_command.rb
+++ b/lib/rubygems/commands/inabox_command.rb
@@ -52,9 +52,11 @@ class Gem::Commands::InaboxCommand < Gem::Command
 
   def send_gem
     # sanitize printed URL if a password is present
-    url = URI.parse(geminabox_host)
+    url = URI.join(geminabox_host, "upload")
+
     url_for_presentation = url.clone
     url_for_presentation.password = '***' if url_for_presentation.password
+
 
     @gemfiles.each do |gemfile|
       say "Pushing #{File.basename(gemfile)} to #{url_for_presentation}..."
@@ -63,7 +65,7 @@ class Gem::Commands::InaboxCommand < Gem::Command
         request_body, request_headers = Multipart::MultipartPost.new.prepare_query("file" => file)
 
         proxy.start(url.host, url.port) {|con|
-          req = Net::HTTP::Post.new(url.path+'/upload', request_headers)
+          req = Net::HTTP::Post.new(url.path, request_headers)
           req.basic_auth(url.user, url.password) if url.user
           handle_response(con.request(req, request_body))
         }


### PR DESCRIPTION
Hi Tom,

the changes from this commit 27f6b084a949888979aba5f96e540475412569bb broke our geminabox clients.
We stored our host url in the config-file with a trailing slash.

So, the push commands was sent to 

<pre>
....geminabox.tld//upload
</pre>

instead of

<pre>
....geminabox.tld/upload
</pre>


To prevent this, I changed the code to use URI.join instead of URI.parse.
With this solution, the concatenation is less fragile.

Best regards,
Jakob Holderbaum
