### PR TITLE
Description taken from first version of gem

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -24,7 +24,7 @@
 
         <div class="details">
           <p>
-            <% if spec = spec_for(name, versions.first.number) %>
+            <% if spec = spec_for(name, versions.last.number) %>
               <%= spec.description %>
               <br/>
               <span class="author">– <%= spec.authors.map do |author|


### PR DESCRIPTION
When moving from 0.3.2 to 0.5.2 I noticed that the description was taken from the first version of the gem. Is this by design? If so, why? I'd rather see the latest versions' description.
