### PR TITLE
implemented support to Rubygems dependencies API.

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -43,6 +43,20 @@ class Geminabox < Sinatra::Base
     erb :atom, :layout => false
   end
 
+  get '/api/v1/dependencies' do
+    query_gems = params[:gems].split(',')
+    deps = load_gems.gems.select {|gem| query_gems.include?(gem.name) }.map do |gem|
+      spec = spec_for(gem.name, gem.number)
+      {
+        :name => gem.name,
+        :number => gem.number.version,
+        :platform => gem.platform,
+        :dependencies => spec.dependencies.select {|dep| dep.type == :runtime}.map {|dep| [dep.name, dep.requirement.to_s] }
+      }
+    end
+    Marshal.dump(deps)
+  end
+
   get '/upload' do
     erb :upload
   end


### PR DESCRIPTION
This will allow Bundler 1.1 to be faster when getting the dependencies from a geminabox server.
