### PR TITLE
Add geminabox version to HTTP responses

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,11 @@ task "test:smoke" do
   require "smoke_test"
 end
 
+Rake::TestTask.new("test:requests") do |t|
+  t.libs << "test" << "lib"
+  t.pattern = "test/requests/**/*_test.rb"
+end
+
 task :st => "test:smoke"
-task :test => "test:integration"
+task :test => ["test:requests", "test:integration"]
 task :default => :test

--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -1,6 +1,9 @@
+$:.push File.expand_path('../lib', __FILE__)
+require 'geminabox'
+
 Gem::Specification.new do |s|
   s.name              = 'geminabox'
-  s.version           = '0.6.0'
+  s.version           = Geminabox::VERSION
   s.summary           = 'Really simple rubygem hosting'
   s.description       = 'A sinatra based gem hosting app, with client side gem push style functionality.'
   s.author            = 'Tom Lea'
@@ -18,5 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency('builder')
   s.add_dependency('httpclient')
   s.add_development_dependency('rake')
+  s.add_development_dependency('rack-test')
   s.add_development_dependency('minitest')
 end

--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -7,6 +7,7 @@ require 'rubygems/indexer'
 require 'hostess'
 
 class Geminabox < Sinatra::Base
+  VERSION = '0.6.0'
   enable :static, :methodoverride
 
   set :public_folder, File.join(File.dirname(__FILE__), *%w[.. public])
@@ -30,6 +31,10 @@ class Geminabox < Sinatra::Base
   end
 
   autoload :GemVersionCollection, "geminabox/gem_version_collection"
+
+  before do
+    headers 'X-Powered-By' => "geminabox #{VERSION}"
+  end
 
   get '/' do
     @gems = load_gems

--- a/test/requests/x_powered_by_test.rb
+++ b/test/requests/x_powered_by_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+require 'minitest/unit'
+require 'rack/test'
+
+class XPoweredByTest < MiniTest::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Geminabox
+  end
+
+  %w[ / /gems ].each do |path|
+    define_method "test: adds X-Powered-By when requesting '#{path}'" do
+      get path
+      assert_equal "geminabox #{Geminabox::VERSION}", last_response.headers['X-Powered-By']
+    end
+  end
+end


### PR DESCRIPTION
It's useful for us to know, which version of which software
is serving gems. This patch adds an `"X-Powered-By"` response
header with the value of `"geminabox VERSION"`, e.g. `"geminabox 0.6.0"`.

Example:

```
geminabox$ bundle exec rackup
$ curl -I localhost:9292
HTTP/1.1 200 OK
...
X-Powered-By: geminabox 0.6.0
```

I'm not too happy with the patch, the code change is virtually a one-liner, but I needed to touch quite some files around it, so I'd gladly improve it if you have any suggestions.
