### PR TITLE
Error out on redirects

### DIFF
--- a/lib/geminabox_client.rb
+++ b/lib/geminabox_client.rb
@@ -28,7 +28,7 @@ class GeminaboxClient
   def push(gemfile)
     response = http_client.post(url_for(:upload), {'file' => File.open(gemfile, "rb")}, {'Accept' => 'text/plain'})
 
-    if response.status < 400
+    if response.status < 300
       response.body
     else
       raise GeminaboxClient::Error, "Error (#{response.code} received)\n\n#{response.body}"


### PR DESCRIPTION
Currently, if a redirect is encountered by the client, it will return successfully with the response body. Not all redirects have response bodies, and the upload was not successful. Ideally the client would follow redirects, but this is a quick fix to avoid silent failure.
