### PR TITLE
using sorted gem list as the cache key to avoid re-computing the results

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -50,8 +50,9 @@ class Geminabox < Sinatra::Base
   end
 
   get '/api/v1/dependencies' do
-    disk_cache.cache(params[:gems]) do
-      query_gems = params[:gems].split(',')
+    query_gems = params[:gems].split(',').sort
+    cache_key = query_gems.join(',')
+    disk_cache.cache(cache_key) do
       deps = load_gems.gems.select {|gem| query_gems.include?(gem.name) }.map do |gem|
         spec = spec_for(gem.name, gem.number)
         {


### PR DESCRIPTION
It appears bundler can requests the same list of gems in different order,

```
[15/Jun/2012:07:54:15 +0000] "GET /api/v1/dependencies?gems=ezcrypto,validates_timeliness,declarative_authorization,blockenspiel,amqp,bunny,open4,cobravsmongoose,parallel,exceptional,rufus-scheduler,daemons,em-http-request,nestegg,opsb-RubyInline,store_base_sti_class_for_3_0,hpricot,auto_strip_attributes,exception_notification_rails3,jsmin,newrelic_rpm,right_aws,SystemTimer,dalli,acts-as-taggable-on HTTP/1.1" 200 4 "-" "-"

[15/Jun/2012:08:22:32 +0000] "GET /api/v1/dependencies?gems=open4,cobravsmongoose,exception_notification_rails3,jsmin,newrelic_rpm,right_aws,SystemTimer,exceptional,dalli,ezcrypto,validates_timeliness,opsb-RubyInline,store_base_sti_class_for_3_0,hpricot,auto_strip_attributes,parallel,rufus-scheduler,daemons,amqp,em-http-request,nestegg,bunny,declarative_authorization,blockenspiel,acts-as-taggable-on HTTP/1.1" 200 4 "-" "-"
```

This causes geminabox to miss it's disk cache and recompute the results (which depending on the number of gems being hosted can be slowish).

This tiny change simply sorts the incoming gem list before using the cache. 
