### PR TITLE
Fixed failing UnwritableDataDir test

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -82,8 +82,8 @@ class Geminabox < Sinatra::Base
 
   post '/upload' do
     if File.exists? Geminabox.data
-      error_response( 500, "Please ensure #{File.expand_path(Geminabox.data)} is writable by the geminabox web server." ) unless File.writable? Geminabox.data
       error_response( 500, "Please ensure #{File.expand_path(Geminabox.data)} is a directory." ) unless File.directory? Geminabox.data
+      error_response( 500, "Please ensure #{File.expand_path(Geminabox.data)} is writable by the geminabox web server." ) unless File.writable? Geminabox.data
     else
       begin
         FileUtils.mkdir_p(settings.data)

--- a/test/integration/pushing_gems/data_dir_errors_test.rb
+++ b/test/integration/pushing_gems/data_dir_errors_test.rb
@@ -9,10 +9,23 @@ class InvalidDataDirTest < Geminabox::TestCase
 end
 
 class UnwritableDataDirTest < Geminabox::TestCase
-  data "/"
+  def setup
+    super
+
+    FileUtils.mkdir '/tmp/read_only'
+    FileUtils.chmod 0444, '/tmp/read_only'
+  end
+
+  def teardown
+    super
+
+    FileUtils.rmdir '/tmp/read_only'
+  end
+
+  data "/tmp/read_only"
 
   test "report the error back to the user" do
-    assert_match %r{Please ensure / is writable by the geminabox web server.}, geminabox_push(gem_file(:example))
+    assert_match %r{Please ensure /tmp/read_only is writable by the geminabox web server.}, geminabox_push(gem_file(:example))
   end
 end
 


### PR DESCRIPTION
The failing test in question was attempting to test for an unwritable directory, but the directory it was creating had read/write privileges (at least it did on my machine)

I added some setup/teardown functionality that changes the permissions to read-only before the test is run.

I also rearranged the logic in the API to test if the data directory exists before it checks if it is writable. Seemed like a more logical order to me.
