### PR TITLE
Don't re-sort GemVersionCollection every time you add a gem

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -123,14 +123,14 @@ class Geminabox < Sinatra::Base
         error_response(200, "Ignoring upload, you uploaded the same thing previously.")
       end
     end
-    
+
     atomic_write(dest_filename) do |f|
       while blk = tmpfile.read(65536)
         f << blk
       end
     end
     reindex
-    
+
     if api_request?
       "Gem #{gem_name} received and indexed."
     else
@@ -211,7 +211,7 @@ HTML
     temp_file.close
     File.rename(temp_file.path, file_name)
   end
-  
+
   helpers do
     def spec_for(gem_name, version)
       spec_file = File.join(settings.data, "quick", "Marshal.#{Gem.marshal_version}", "#{gem_name}-#{version}.gemspec.rz")

--- a/lib/geminabox/gem_version_collection.rb
+++ b/lib/geminabox/gem_version_collection.rb
@@ -12,6 +12,7 @@ class Geminabox::GemVersionCollection
   def initialize(initial_gems=[])
     @gems = []
     initial_gems.each { |gemdef| self << gemdef }
+    sort!
   end
 
   def <<(version_or_def)
@@ -22,7 +23,6 @@ class Geminabox::GemVersionCollection
               end
 
     @gems << version
-    @gems.sort!
   end
 
   def oldest
@@ -52,6 +52,10 @@ class Geminabox::GemVersionCollection
     else
       grouped
     end
+  end
+
+  def sort!
+    @gems.sort!
   end
 
   private


### PR DESCRIPTION
We have a decently large gem repository at work (almost 800 gems), and geminabox is pretty much unusable. Loading the index or uploading a gem is a ~30 second affair.

This change fixes it so that GemVersionCollection sorts its gem list only once on initialization, instead of every time a gem is pushed onto the list. I haven't done any hard benchmarks, but the usual operations are now as close to instantaneous as I would reasonably expect.
