### PR TITLE
Geminabox does not work with older versions of httpclient.

### DIFF
--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('sinatra')
   s.add_dependency('builder')
-  s.add_dependency('httpclient')
+  s.add_dependency('httpclient', [">= 2.2.7"])
   s.add_development_dependency('rake')
   s.add_development_dependency('rack-test')
   s.add_development_dependency('minitest')


### PR DESCRIPTION
We see this issue when trying to publish a gem with an older version
of httpclient (2.1.5.2). When using a newer version (2.2.7) it publishes
just fine.
  $ gem inabox
  You didn't specify a gem, looking for one in . and in ./pkg/...
  ERROR:  While executing gem ... (ArgumentError)
      wrong number of arguments (1 for 2)
