### PR TITLE
removed timeouts on http_client when uploading.

### DIFF
--- a/lib/geminabox_client.rb
+++ b/lib/geminabox_client.rb
@@ -10,7 +10,8 @@ class GeminaboxClient
     @http_client.set_auth(url_for(:upload), @username, @password) if @username or @password
     @http_client.www_auth.basic_auth.challenge(url_for(:upload)) # Workaround: https://github.com/nahi/httpclient/issues/63
     @http_client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    @http_client.send_timeout = 600
+    @http_client.send_timeout = 0
+    @http_client.receive_timeout = 0
   end
 
   def extract_username_and_password_from_url!(url)


### PR DESCRIPTION
As per recommendations at https://github.com/nahi/httpclient, have set the send_timeout and receive_timeout to 0 when uploading large files:

LIMITATION:
          timeout occurs certainly when you send very large file and
          @send_timeout is default since HTTPClient::Session#query() assumes
          that _all_ write are finished in @send_timeout sec not each write.
    
        WORKAROUND:
          increment @send_timeout and @receive_timeout or set @send_timeout and
          @receive_timeout to 0 not to be timeout.
