### PR TITLE
Added rubygems push API compatibility

### DIFF
--- a/lib/geminabox/incoming_gem.rb
+++ b/lib/geminabox/incoming_gem.rb
@@ -1,0 +1,32 @@
+class Geminabox::IncomingGem
+  attr_reader :spec, :gem_data
+
+  def initialize(gem_data)
+    @gem_data = gem_data
+  end
+
+  def valid?
+    spec && spec.name && spec.version
+  rescue Gem::Package::Error
+    false
+  end
+
+  def spec
+    return @spec if @spec
+    Gem::Package.open(StringIO.new(gem_data), "r", nil) do |pkg|
+      @spec = pkg.metadata
+    end
+  end
+
+  def name
+    "#{spec.name}-#{spec.version}.gem"
+  end
+
+  def dest_filename
+    File.join(Geminabox.settings.data, "gems", name)
+  end
+
+  def hexdigest
+    Digest::SHA1.hexdigest(gem_data)
+  end
+end


### PR DESCRIPTION
This adds support for Rubygems' POST /api/v1/gems API endpoint, so that the standard `gem push` works seamlessly against a geminabox server. This should include plugins like gem-release etc.

Note that I haven't added any new tests for this yet. All the real code is already exercised by the integration tests since it is shared with the existing upload functionality. The whole tar is also read into memory which isn't ideal -- maybe someone has ideas on how to avoid that. If the functionality in this PR is wanted I can try to address these two issues.
