### PR TITLE
updated README to include 'rackup'

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,7 +27,7 @@ Create a config.ru as follows:
     Geminabox.data = "/var/geminabox-data" # ... or wherever
     run Geminabox
 
-And finally, hook up the config.ru as you normally would ([passenger][passenger], [thin][thin], [unicorn][unicorn], whatever floats your boat).
+Start your gem server with 'rackup' to run WEBrick or hook up the config.ru as you normally would ([passenger][passenger], [thin][thin], [unicorn][unicorn], whatever floats your boat).
 
 ## Legacy RubyGems index
 


### PR DESCRIPTION
Hey Tom!

Thanks for building geminabox. I just used it to build a private gem. 

In going through the README, I believe that it would be helpful to include mention of 'rackup' in the beginning of the last line under "Server Setup" like so:

“Start your gem server with 'rackup' to run WEBrick or hook up the config.ru as you normally would ([passenger][passenger], [thin][thin], [unicorn][unicorn], whatever floats your boat).”

I hope that this can save other developers time from having to look up the 'rackup' command.

All the best,  
Linda
