### PR TITLE
Fix crash when gemspec is missing for a named gem

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -242,16 +242,26 @@ HTML
     # Return a list of versions of gem 'gem_name' with the dependencies of each version.
     def gem_dependencies(gem_name)
       dependency_cache.marshal_cache(gem_name) do
-        load_gems.select {|gem| gem_name == gem.name }.map do |gem|
-          spec = spec_for(gem.name, gem.number)
-          {
-            :name => gem.name,
-            :number => gem.number.version,
-            :platform => gem.platform,
-            :dependencies => spec.dependencies.select {|dep| dep.type == :runtime}.map {|dep| [dep.name, dep.requirement.to_s] }
-          }
-        end
+        load_gems.
+          select { |gem| gem_name == gem.name }.
+          map    { |gem| [gem, spec_for(gem.name, gem.number)] }.
+          reject { |(_, spec)| spec.nil? }.
+          map do |(gem, spec)|
+            {
+              :name => gem.name,
+              :number => gem.number.version,
+              :platform => gem.platform,
+              :dependencies => runtime_dependencies(spec)
+            }
+          end
       end
+    end
+
+    def runtime_dependencies(spec)
+      spec.
+        dependencies.
+        select { |dep| dep.type == :runtime }.
+        map    { |dep| [dep.name, dep.requirement.to_s] }
     end
   end
 end


### PR DESCRIPTION
Given a gem that appears in specs or prerelease_specs and has no local gemspec.rz, when I request that gem's dependencies via the API, geminabox will crash. This change suppresses gems without a local gemspec from the dependency report. 
