### PR TITLE
Fix support for platform dependent gems

### DIFF
--- a/lib/geminabox/incoming_gem.rb
+++ b/lib/geminabox/incoming_gem.rb
@@ -42,7 +42,12 @@ class Geminabox::IncomingGem
   end
 
   def name
-    "#{spec.name}-#{spec.version}.gem"
+    unless @name
+      filename = %W[#{spec.name} #{spec.version}]
+      filename.push(spec.platform) if spec.platform && spec.platform != "ruby"
+      @name = filename.join("-") + ".gem"
+    end
+    @name
   end
 
   def dest_filename

--- a/test/test_support/gem_factory.rb
+++ b/test/test_support/gem_factory.rb
@@ -8,9 +8,10 @@ class GemFactory
   end
 
   def gem(name, options = {})
-    version = options[:version] || "1.0.0"
+    version  = options[:version] || "1.0.0"
+    platform = options[:platform] || "ruby"
 
-    dependincies = options.fetch(:deps, {}).collect do |dep, requirement|
+    dependencies = options.fetch(:deps, {}).collect do |dep, requirement|
       dep = [*dep]
       gem(*dep)
       if requirement
@@ -21,7 +22,9 @@ class GemFactory
     end.join("\n")
 
     name = name.to_s
-    path = @path.join("#{name}-#{version}.gem")
+    filename = %W[#{name} #{version}]
+    filename.push(platform) if platform != "ruby"
+    path = @path.join("#{filename.join("-")}.gem")
     FileUtils.mkdir_p File.dirname(path)
 
     unless File.exists? path 
@@ -29,11 +32,12 @@ class GemFactory
         Gem::Specification.new do |s|
           s.name              = #{name.inspect}
           s.version           = #{version.inspect}
+          s.platform          = #{platform.inspect}
           s.summary           = #{name.inspect}
           s.description       = s.summary + " description"
           s.author            = 'Test'
           s.files             = []
-          #{dependincies}
+          #{dependencies}
         end
       }
 

--- a/test/units/gem_version_collection_test.rb
+++ b/test/units/gem_version_collection_test.rb
@@ -13,12 +13,13 @@ class GemVersionCollectionTest < MiniTest::Unit::TestCase
     subject = GIB::GemVersionCollection.new([
       ['foo', '1.2.3', 'ruby'],
       ['foo', '1.2.4', 'ruby'],
-      ['bar', '1.2.4', 'ruby']
+      ['bar', '1.2.4', 'ruby'],
+      ['foo', '1.2.4', 'x86_amd64-linux'],
     ])
 
     actual = Hash[subject.by_name]
     assert_equal GIB::GemVersionCollection, actual['foo'].class
-    assert_equal 2, actual['foo'].size
+    assert_equal 3, actual['foo'].size
     assert_equal 1, actual['bar'].size
   end
 

--- a/test/units/incoming_gem_test.rb
+++ b/test/units/incoming_gem_test.rb
@@ -31,6 +31,13 @@ class IncomingGemTest < MiniTest::Unit::TestCase
     assert_equal "example-1.0.0.gem", subject.name
   end
 
+  test "#name for platform dependent gem" do
+    file = File.open(GemFactory.gem_file(:example, :platform => "x86_64-linux"))
+    subject = Geminabox::IncomingGem.new(file)
+
+    assert_equal "example-1.0.0-x86_64-linux.gem", subject.name
+  end
+
   test "#dest_filename" do
     file = File.open(GemFactory.gem_file(:example))
     subject = Geminabox::IncomingGem.new(file, "/root/path")


### PR DESCRIPTION
Playing with the current version of geminabox I'm experiencing some problems uploading and handling platform dependent gems, e.g. libv8 [1].

Once a platform dependent gem is uploaded, the generated filename doesn't include platform information. That creates problems uploading the same gem for another platform and deleting the gem (in the end I had to remove the gem from the command line).

I have created a patch with the changes to make this work again. Please let me know if you need further information or any change.

[1] https://rubygems.org/gems/libv8
