### PR TITLE
Fixes dependency api to support empty gem params as bundler uses that to ping the dependency api

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -55,8 +55,12 @@ class Geminabox < Sinatra::Base
   end
 
   get '/api/v1/dependencies' do
-    query_gems = params[:gems].split(',')
-    deps = query_gems.inject([]){|memo, query_gem| memo + gem_dependencies(query_gem) }
+    deps = if params[:gems]
+      query_gems = params[:gems].split(',')
+      query_gems.inject([]){|memo, query_gem| memo + gem_dependencies(query_gem) }
+    else
+      []
+    end
     Marshal.dump(deps)
   end
 

--- a/test/integration/dependency_api/dependencies_api_test.rb
+++ b/test/integration/dependency_api/dependencies_api_test.rb
@@ -65,6 +65,11 @@ class DependenciesApiTest < Geminabox::TestCase
     assert_equal expected, deps
   end
 
+  test "dependency api with empty params" do
+    deps = Marshal.load HTTPClient.new.get_content(url_for("api/v1/dependencies"))
+    assert_equal [], deps
+  end
+
 protected
   def fetch_deps(*gems)
     Marshal.load HTTPClient.new.get_content(url_for("api/v1/dependencies?gems=#{gems.join(",")}"))


### PR DESCRIPTION
Otherwise, the current bundler never uses the dependency api.
