### PR TITLE
Fix 500 when the `gems` parameter is excluded from the dependencies call

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -55,7 +55,7 @@ class Geminabox < Sinatra::Base
   end
 
   get '/api/v1/dependencies' do
-    query_gems = params[:gems].split(',')
+    query_gems = (params[:gems] or '').split(',')
     deps = query_gems.inject([]){|memo, query_gem| memo + gem_dependencies(query_gem) }
     Marshal.dump(deps)
   end


### PR DESCRIPTION
I've noticed Bundler does this call without any parameters and then again with some comma separated gems. This prevents a 500 when it does this.
