### PR TITLE
Mention gemcutter push support in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,6 +38,12 @@ RubyGems supports generating indexes for the so called legacy versions (< 1.2), 
 
 ## Client Usage
 
+Since version 0.10, Geminabox supports the standard gemcutter push API:
+
+    gem push pkg/my-awesome-gem-1.0.gem --host HOST
+
+You can also use the gem plugin:
+
     gem install geminabox
 
     gem inabox pkg/my-awesome-gem-1.0.gem


### PR DESCRIPTION
The push support wasn't mentioned anywhere in the readme. I believe that this can be used to close #41 since there no longer is a need for a separate client-only gem.
