### PR TITLE
Specify minimum required version of sinatra dependency

### DIFF
--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files             = %w[README.markdown] + Dir['{lib,public,views}/**/*']
   s.require_paths     = ['lib']
 
-  s.add_dependency('sinatra')
+  s.add_dependency('sinatra', [">= 1.2.7"])
   s.add_dependency('builder')
   s.add_dependency('httpclient', [">= 2.2.7"])
   s.add_development_dependency('rake')


### PR DESCRIPTION
I ran into issue #86 because I had an old version of sinatra installed. This commit simply specifies a minimum version for sinatra as a dependency of geminabox.
