### PR TITLE
Fix some Ruby encoding conversion problems

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -234,6 +234,7 @@ HTML
     temp_dir = File.join(settings.data, "_temp")
     FileUtils.mkdir_p(temp_dir)
     temp_file = Tempfile.new("." + File.basename(file_name), temp_dir)
+    temp_file.binmode
     yield temp_file
     temp_file.close
     File.rename(temp_file.path, file_name)


### PR DESCRIPTION
A Ruby encoding exception gets raised if I try to upload a gem using the web interface. This change fixes the problem.
