### PR TITLE
Typo fix (E.g. => e.g.)

### DIFF
--- a/lib/rubygems/commands/inabox_command.rb
+++ b/lib/rubygems/commands/inabox_command.rb
@@ -68,7 +68,7 @@ class Gem::Commands::InaboxCommand < Gem::Command
   end
 
   def configure
-    say "Enter the root url for your personal geminabox instance. (E.g. http://gems/)"
+    say "Enter the root url for your personal geminabox instance. (e.g. http://gems/)"
     host = ask("Host:")
     self.geminabox_host = host
   end


### PR DESCRIPTION
e.g. is always with lowercase letters.
