### PR TITLE
Use relative path for asset

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -2,15 +2,15 @@
 <html>
   <head>
     <title>Gem in a Box</title>
-    <link rel="stylesheet" href="<%= url "/master.css" %>" type="text/css" media="screen">
-    <link href="<%= url "/atom.xml" %>" type="application/atom+xml" rel="alternate" title="Atom Feed">
+    <link rel="stylesheet" href="<%= url "/master.css", false %>" type="text/css" media="screen">
+    <link href="<%= url "/atom.xml", false %>" type="application/atom+xml" rel="alternate" title="Atom Feed">
   </head>
   <body>
     <div id="content">
       <h1>Gem in a Box</h1>
       <%= yield %>
     </div>
-    <script type="text/javascript" src="<%= url "/jquery.js" %>"></script>
-    <script type="text/javascript" src="<%= url "/master.js" %>"></script>
+    <script type="text/javascript" src="<%= url "/jquery.js", false %>"></script>
+    <script type="text/javascript" src="<%= url "/master.js", false %>"></script>
   </body>
 </html>


### PR DESCRIPTION
When geminabox is running as socket behind nginx, geminabox doesn't seem to know whether it's accessed via https or http. It would be better to use relative path.
