### PR TITLE
Remove unnecessary rubygems request in proxy mode

### DIFF
--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -88,11 +88,11 @@ module Geminabox
     end
 
     get '/api/v1/dependencies' do
-      Marshal.dump(gem_list)
+      query_gems.any? ? Marshal.dump(gem_list) : 200
     end
 
     get '/api/v1/dependencies.json' do
-      gem_list.to_json
+      query_gems.any? ? gem_list.to_json : {}
     end
 
     get '/upload' do

--- a/test/integration/dependency_api/dependencies_api_test.rb
+++ b/test/integration/dependency_api/dependencies_api_test.rb
@@ -66,8 +66,8 @@ class DependenciesApiTest < Geminabox::TestCase
   end
 
   test "dependency api with empty params" do
-    deps = Marshal.load HTTPClient.new.get_content(url_for("api/v1/dependencies"))
-    assert_equal [], deps
+    request = HTTPClient.new.get(url_for("api/v1/dependencies"))
+    assert_equal 200, request.status
   end
 
   test "get dependencies for multiple gems as json" do


### PR DESCRIPTION
Without any specified gems, there is no need to ping rubygems.org. It's
assumed that bundler does this request to check whether the dependency
API is supported.

@reggieb I'm currently about to remove the hard dependency on rubygems.org availability in proxy mode. This is just the first very low hanging fruit, the other dependency calls are a bit more tricky. I was thinking about adding an option to cache the results of rubygems.org/api/v1/dependencies requests and having something periodically refresh the cache. Thoughts? 
