### PR TITLE
Adds HttpAdapter to allow use of alternative HTTP gems 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,6 +48,21 @@ Or in config.ru (before the run command), set:
 
     Geminabox.rubygems_proxy = true
 
+## HTTP adapter
+
+Geminabox uses the HTTPClient gem to manage its connections to remote resources.
+The relationship is managed via Geminabox::HttpClientAdapter.
+
+If you would like to use an alternative HTTP gem, create your own adapter
+and specify it in config.ru:
+
+    Geminabox.http_adapter = YourHttpAdapter.new
+
+It is recommend (but not essential) that your adapter inherits from HttpAdapter.
+The adapter will need to replace HttpAdapter's methods with those specific to
+the alternative HTTP gem. It should also be able to handle HTTP proxy
+settings.
+
 ## Client Usage
 
 Since version 0.10, Geminabox supports the standard gemcutter push API:

--- a/console.sh
+++ b/console.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo Opening Ruby shell with Geminabox loaded
-irb -r ./lib/geminabox
+bundle exec irb

--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -13,21 +13,22 @@ module Geminabox
 
   require_relative 'geminabox/version'
   require_relative 'geminabox/proxy'
+  require_relative 'geminabox/http_adapter'
 
   def self.geminabox_path(file)
     File.join File.dirname(__FILE__), 'geminabox', file
   end
 
-  autoload :Hostess,              geminabox_path('hostess')
-  autoload :GemStore,             geminabox_path('gem_store')
-  autoload :GemStoreError,        geminabox_path('gem_store_error')
-  autoload :RubygemsDependency,   geminabox_path('rubygems_dependency')
-  autoload :GemListMerge,         geminabox_path('gem_list_merge')
-  autoload :GemVersion,           geminabox_path('gem_version')
-  autoload :GemVersionCollection, geminabox_path('gem_version_collection')
-  autoload :Server,               geminabox_path('server')
-  autoload :DiskCache,            geminabox_path('disk_cache')
-  autoload :IncomingGem,          geminabox_path('incoming_gem')
+  autoload :Hostess,                geminabox_path('hostess')
+  autoload :GemStore,               geminabox_path('gem_store')
+  autoload :GemStoreError,          geminabox_path('gem_store_error')
+  autoload :RubygemsDependency,     geminabox_path('rubygems_dependency')
+  autoload :GemListMerge,           geminabox_path('gem_list_merge')
+  autoload :GemVersion,             geminabox_path('gem_version')
+  autoload :GemVersionCollection,   geminabox_path('gem_version_collection')
+  autoload :Server,                 geminabox_path('server')
+  autoload :DiskCache,              geminabox_path('disk_cache')
+  autoload :IncomingGem,            geminabox_path('incoming_gem')
 
   class << self
 
@@ -40,7 +41,8 @@ module Geminabox
       :allow_replace,
       :gem_permissions,
       :allow_delete,
-      :rubygems_proxy
+      :rubygems_proxy,
+      :http_adapter
     )
 
     def set_defaults(defaults)
@@ -69,7 +71,8 @@ module Geminabox
     allow_replace:       false,
     gem_permissions:     0644,
     rubygems_proxy:      (ENV['RUBYGEMS_PROXY'] == 'true'),
-    allow_delete:        true
+    allow_delete:        true,
+    http_adapter:        HttpClientAdapter.new
 
   )
     

--- a/lib/geminabox/http_adapter.rb
+++ b/lib/geminabox/http_adapter.rb
@@ -1,0 +1,27 @@
+require_relative 'http_adapter_config_error'
+
+module Geminabox
+  class HttpAdapter
+
+    def get_content(*args)
+      raise HttpAdapterConfigError.new(:get_content, 'the response body')
+    end
+
+    def get(*args)
+      raise HttpAdapterConfigError.new(:get, 'a response object')
+    end
+
+    def post(*args)
+      raise HttpAdapterConfigError.new(:post, 'a response object')
+    end
+
+    def set_auth(*args)
+      raise HttpAdapterConfigError.new(:set_auth, 'true')
+    end
+
+  end
+end
+
+Dir[File.expand_path('http_adapter/*.rb', File.dirname(__FILE__))].each do |file|
+  require file
+end

--- a/lib/geminabox/http_adapter/http_client_adapter.rb
+++ b/lib/geminabox/http_adapter/http_client_adapter.rb
@@ -1,0 +1,32 @@
+require 'httpclient'
+
+module Geminabox
+
+  class HttpClientAdapter < HttpAdapter
+
+    def get(*args)
+      http_client.get(*args)
+    end
+
+    def get_content(*args)
+      http_client.get_content(*args)
+    end
+
+    def post(*args)
+      http_client.post(*args)
+    end
+
+    def set_auth(url, username = nil, password = nil)
+      http_client.set_auth(url, username, password) if username or password
+      http_client.www_auth.basic_auth.challenge(url) # Workaround: https://github.com/nahi/httpclient/issues/63
+      http_client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http_client.send_timeout = 0
+      http_client.receive_timeout = 0
+    end
+
+    def http_client
+      @http_client ||= HTTPClient.new(ENV['http_proxy'])
+    end
+
+  end
+end

--- a/lib/geminabox/http_adapter_config_error.rb
+++ b/lib/geminabox/http_adapter_config_error.rb
@@ -1,0 +1,7 @@
+module Geminabox
+  class HttpAdapterConfigError < StandardError
+    def initialize(method_name, returns)
+      super("#{method_name} must be defined, and return #{returns}")
+    end
+  end
+end

--- a/lib/geminabox/proxy/file_handler.rb
+++ b/lib/geminabox/proxy/file_handler.rb
@@ -1,4 +1,4 @@
-require 'httpclient'
+
 module Geminabox
   module Proxy
     class FileHandler
@@ -43,7 +43,7 @@ module Geminabox
       end
 
       def remote_content
-        HTTPClient.get_content(remote_url).force_encoding(encoding)
+        Geminabox.http_adapter.get_content(remote_url).force_encoding(encoding)
       rescue
         raise GemStoreError.new(500, "Unable to get content from #{remote_url}")
       end

--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -59,19 +59,12 @@ module Geminabox
         file = File.expand_path(File.join(Server.data, *request.path_info))
 
         unless File.exists?(file)
-          net_http_class.start("production.cf.rubygems.org") do |http|
-            path = File.join(*request.path_info)
-            response = http.get(path)
-            GemStore.create(IncomingGem.new(StringIO.new(response.body)))
-          end
+          ruby_gems_url = 'http://production.cf.rubygems.org'
+          path = File.join(ruby_gems_url, *request.path_info)
+          content = Geminabox.http_adapter.get_content(path)
+          GemStore.create(IncomingGem.new(StringIO.new(content)))
         end
 
-      end
-
-      def net_http_class
-        return ::Net::HTTP unless ENV['http_proxy']
-        proxy_uri = URI.parse(ENV['http_proxy'])
-        ::Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
       end
 
       def splice_file(file_name)

--- a/lib/geminabox/rubygems_dependency.rb
+++ b/lib/geminabox/rubygems_dependency.rb
@@ -1,4 +1,3 @@
-require 'httpclient'
 require 'json'
 
 module Geminabox
@@ -13,7 +12,7 @@ module Geminabox
           '?gems=',
           gems.map(&:to_s).join(',')
         ].join
-        body = HTTPClient.get_content(url)
+        body = Geminabox.http_adapter.get_content(url)
         JSON.parse(body)
       end
 

--- a/lib/geminabox_client.rb
+++ b/lib/geminabox_client.rb
@@ -1,17 +1,13 @@
 require 'uri'
-require 'httpclient'
+require 'geminabox'
 
 class GeminaboxClient
   attr_reader :url, :http_client
 
   def initialize(url)
     extract_username_and_password_from_url!(url)
-    @http_client = HTTPClient.new
-    @http_client.set_auth(url_for(:upload), @username, @password) if @username or @password
-    @http_client.www_auth.basic_auth.challenge(url_for(:upload)) # Workaround: https://github.com/nahi/httpclient/issues/63
-    @http_client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    @http_client.send_timeout = 0
-    @http_client.receive_timeout = 0
+    @http_client = Geminabox.http_adapter
+    @http_client.set_auth(url_for(:upload), @username, @password) 
   end
 
   def extract_username_and_password_from_url!(url)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,11 +2,12 @@ require "rubygems"
 gem "bundler"
 require "bundler/setup"
 
-require 'geminabox'
+require_relative '../lib/geminabox'
 require 'minitest/autorun'
 require 'fileutils'
 require 'test_support/gem_factory'
 require 'test_support/geminabox_test_case'
+require 'test_support/http_dummy'
 
 require 'capybara/mechanize'
 require 'capybara/dsl'

--- a/test/test_support/http_dummy.rb
+++ b/test/test_support/http_dummy.rb
@@ -1,0 +1,42 @@
+module Geminabox
+  class HttpDummy < HttpAdapter
+
+    attr_accessor :default_response
+
+    def get_content(*args)
+      default_response
+    end
+
+    def get(*args)
+      Response.new default_response
+    end
+
+    def post(*args)
+      Response.new default_response
+    end
+
+    def set_auth(*args)
+      true
+    end
+
+    class Response
+      attr_reader :default
+      def initialize(default)
+        @default = default
+      end
+
+      def body
+        default
+      end
+
+      def status
+        default
+      end
+
+      def code
+        default
+      end
+    end
+
+  end
+end

--- a/test/units/geminabox/http_adapter/http_dummy_test.rb
+++ b/test/units/geminabox/http_adapter/http_dummy_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+module Geminabox
+  class HttpDummyTest < Minitest::Test
+
+    def setup
+      @default = 'foo bar'
+      @http_dummy = HttpDummy.new
+      @http_dummy.default_response = @default
+    end
+
+    def teardown
+      Geminabox.http_adapter = HttpClientAdapter.new
+    end
+
+    def test_get_content
+      assert_equal @default, @http_dummy.get_content('http://example.com')
+    end
+
+    def test_get
+      response = @http_dummy.get('http://example.com')
+      assert_equal @default, response.body
+      assert_equal @default, response.status
+      assert_equal @default, response.code
+    end
+
+    def test_post
+      response = @http_dummy.post('http://example.com')
+      assert_equal @default, response.body
+      assert_equal @default, response.status
+      assert_equal @default, response.code
+    end
+
+    def test_set_auth
+      assert_equal true, @http_dummy.set_auth('http://example', 'foo', 'bar')
+    end
+
+  end
+end

--- a/test/units/geminabox/http_adapter_test.rb
+++ b/test/units/geminabox/http_adapter_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+module Geminabox
+  class HttpAdapterTest < Minitest::Test
+    def http_adapter
+      @http_handler ||= HttpAdapter.new
+    end
+
+    def test_get_content
+      assert_raises HttpAdapterConfigError do
+        http_adapter.get_content('http://example.com')
+      end
+    end
+
+    def test_get
+      assert_raises HttpAdapterConfigError do
+        http_adapter.get('http://example.com')
+      end
+    end
+
+    def test_post
+      assert_raises HttpAdapterConfigError do
+        http_adapter.post('http://example.com')
+      end
+    end
+
+    def test_set_auth
+      assert_raises HttpAdapterConfigError do
+        http_adapter.set_auth('http://example', 'foo', 'bar')
+      end
+    end
+
+    def test_default_geminabox_http_adapter
+      assert_kind_of HttpClientAdapter, Geminabox.http_adapter
+    end
+  end
+end

--- a/test/units/geminabox/proxy/file_handler_test.rb
+++ b/test/units/geminabox/proxy/file_handler_test.rb
@@ -8,6 +8,10 @@ module Geminabox
         clean_data_dir
       end
 
+      def teardown
+        Geminabox.http_adapter = HttpClientAdapter.new
+      end
+
       def test_with_no_files_in_place
         assert_equal false, file_handler.local_file_exists?
         assert_equal false, file_handler.proxy_file_exists?
@@ -28,6 +32,13 @@ module Geminabox
       def test_remote_content
         stub_request(:get, "http://rubygems.org/foo/bar").
           to_return(:status => 200, :body => remote_content)
+        assert_equal remote_content, file_handler.remote_content
+      end
+
+      def test_remote_content_with_alternative_http_adapter
+        @http_dummy = HttpDummy.new
+        @http_dummy.default_response = remote_content
+        Geminabox.http_adapter = @http_dummy
         assert_equal remote_content, file_handler.remote_content
       end
       


### PR DESCRIPTION
I've refactored the relationship between Geminabox and HTTPClient, to facilitate using an alternative HTTP gem. See the new README on how to set up an alternative adapter.

I've included two adapters: HttpClientAdapter and HttpDummy (latter in tests/support) which should provide enough on an example for people wanting to create their own adapters.
