### PR TITLE
Temp file must be open as binary.

### DIFF
--- a/lib/geminabox/incoming_gem.rb
+++ b/lib/geminabox/incoming_gem.rb
@@ -10,7 +10,7 @@ module Geminabox
       if RbConfig::CONFIG["MAJOR"].to_i <= 1 and RbConfig::CONFIG["MINOR"].to_i <= 8
         @tempfile = Tempfile.new("gem")
       else
-        @tempfile = Tempfile.new("gem", :encoding => 'binary')
+        @tempfile = Tempfile.new("gem", :encoding => 'binary', :binmode => true)
       end
 
       while data = gem_data.read(1024**2)


### PR DESCRIPTION
This is causing problems in Windows based systems for me.

When creating tempfile in Mac this is working flawlessly but deploying on a Windows machine this is causing problems. The file is opened in text mode and the zip of the gem gets corrupted.
