### PR TITLE
add port option for webrick server

### DIFF
--- a/lib/rubygems/commands/inabox_command.rb
+++ b/lib/rubygems/commands/inabox_command.rb
@@ -27,6 +27,10 @@ class Gem::Commands::InaboxCommand < Gem::Command
     add_option('-o', '--overwrite', "Overwrite Gem.") do |value, options|
       options[:overwrite] = true
     end
+
+    add_option('-p', '--port', "Sets port") do |value, options|
+      options[:port] = value
+    end
   end
 
   def last_minute_requires!


### PR DESCRIPTION
This way you can rackup the gem server with the -p / --port option to define which port the server listens to
