### PR TITLE
[FIX] Pins webmock at 1.19.0 to prevent RubyGemDependencyTest#test_get_list failing with error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ group :test do
   gem 'rack-test'
   gem 'minitest'
   gem 'capybara-mechanize'
-  gem 'webmock'
+  gem 'webmock', '1.19.0'
 end


### PR DESCRIPTION
With default installation, `RubyGemDependencyTest#test_get_list` fails with error:

```
ruby 1.9.3p547 (2014-05-14 revision 45962) [x86_64-linux]

Your Gemfile lists the gem rake (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
Resolving dependencies...
Using rake 10.3.2
Using addressable 2.3.6
Using builder 3.2.2
Using mime-types 2.4.3
Using mini_portile 0.6.1
Using nokogiri 1.6.4.1
Using rack 1.5.2
Using rack-test 0.6.2
Using xpath 2.0.0
Using capybara 2.4.4
Using unf_ext 0.0.6
Using unf 0.1.4
Using domain_name 0.5.22
Using http-cookie 1.0.2
Using net-http-digest_auth 1.4
Using net-http-persistent 2.9.4
Using ntlm-http 0.1.1
Using webrobots 0.1.1
Using mechanize 2.7.3
Using capybara-mechanize 1.4.0
Using safe_yaml 1.0.4
Using crack 0.4.2
Using multipart-post 2.0.0
Using faraday 0.9.0
Using httpclient 2.5.3.2
Using nesty 1.0.2
Using rack-protection 1.5.3
Using tilt 1.4.1
Using sinatra 1.4.5
Using geminabox 0.12.4 from source at .
Using minitest 5.4.2
Using webmock 1.20.3
Using bundler 1.6.2
Your bundle is complete!
Gems in the group development were not installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
Your Gemfile lists the gem rake (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
Run options: --name test_get_list --seed 24093

# Running:

E

Finished in 0.002191s, 456.3751 runs/s, 0.0000 assertions/s.

  1) Error:
Geminabox::RubyGemDependencyTest#test_get_list:
ArgumentError: Unknown key: "content_type". Valid keys are: "headers", "status", "body", "exception", "should_timeout"
    /home/ben/.rvm/gems/ruby-1.9.3-p547/gems/webmock-1.20.3/lib/webmock/util/hash_validator.rb:12:in `block in validate_keys'
    /home/ben/.rvm/gems/ruby-1.9.3-p547/gems/webmock-1.20.3/lib/webmock/util/hash_validator.rb:10:in `each_key'
    /home/ben/.rvm/gems/ruby-1.9.3-p547/gems/webmock-1.20.3/lib/webmock/util/hash_validator.rb:10:in `validate_keys'
    /home/ben/.rvm/gems/ruby-1.9.3-p547/gems/webmock-1.20.3/lib/webmock/response.rb:80:in `options='
    /home/ben/.rvm/gems/ruby-1.9.3-p547/gems/webmock-1.20.3/lib/webmock/response.rb:25:in `initialize'
    /home/ben/.rvm/gems/ruby-1.9.3-p547/gems/webmock-1.20.3/lib/webmock/response.rb:15:in `new'
    /home/ben/.rvm/gems/ruby-1.9.3-p547/gems/webmock-1.20.3/lib/webmock/response.rb:15:in `response_for'
    /home/ben/.rvm/gems/ruby-1.9.3-p547/gems/webmock-1.20.3/lib/webmock/request_stub.rb:21:in `block in to_return'
    /home/ben/.rvm/gems/ruby-1.9.3-p547/gems/webmock-1.20.3/lib/webmock/request_stub.rb:21:in `map'
    /home/ben/.rvm/gems/ruby-1.9.3-p547/gems/webmock-1.20.3/lib/webmock/request_stub.rb:21:in `to_return'
    test/units/geminabox/rubygems_dependency_test.rb:13:in `test_get_list'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

The [latest build](https://travis-ci.org/geminabox/geminabox/jobs/38237134) uses `1.19.0`