### PR TITLE
Make GemStore configurable

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -43,7 +43,8 @@ module Geminabox
       :allow_delete,
       :rubygems_proxy,
       :http_adapter,
-      :allow_remote_failure
+      :allow_remote_failure,
+      :gem_store
     )
 
     def set_defaults(defaults)
@@ -73,7 +74,8 @@ module Geminabox
     rubygems_proxy:       (ENV['RUBYGEMS_PROXY'] == 'true'),
     allow_delete:         true,
     http_adapter:         HttpClientAdapter.new,
-    allow_remote_failure: false
+    allow_remote_failure: false,
+    gem_store:            GemStore
   )
     
 end

--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -62,7 +62,7 @@ module Geminabox
           ruby_gems_url = 'http://production.cf.rubygems.org'
           path = File.join(ruby_gems_url, *request.path_info)
           content = Geminabox.http_adapter.get_content(path)
-          GemStore.create(IncomingGem.new(StringIO.new(content)))
+          Geminabox.gem_store.create(IncomingGem.new(StringIO.new(content)))
         end
 
       end

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -16,7 +16,8 @@ module Geminabox
       :allow_replace,
       :gem_permissions,
       :allow_delete,
-      :rubygems_proxy
+      :rubygems_proxy,
+      :gem_store
     )
 
     if Server.rubygems_proxy
@@ -142,7 +143,7 @@ module Geminabox
 
     def handle_incoming_gem(gem)
       begin
-        GemStore.create(gem, params[:overwrite])
+        settings.gem_store.create(gem, params[:overwrite])
       rescue GemStoreError => error
         error_response error.code, error.reason
       end

--- a/test/units/geminabox/rubygems_dependency_test.rb
+++ b/test/units/geminabox/rubygems_dependency_test.rb
@@ -11,7 +11,7 @@ module Geminabox
 
     def test_get_list
       stub_request(:get, "https://bundler.rubygems.org/api/v1/dependencies.json?gems=some_gem,other_gem").
-        to_return(:status => 200, :body => some_gem_dependencies.to_json, :headers => {}, :content_type => 'application/json')
+        to_return(:status => 200, :body => some_gem_dependencies.to_json, :headers => {:content_type => 'application/json'})
 
       assert_equal some_gem_dependencies, RubygemsDependency.for(:some_gem, :other_gem)
     end


### PR DESCRIPTION
To allow other gem store implementations. I'm planning to implement a
gem store using Amazon S3.