### PR TITLE
Fix: ensure nothing is cached in case of failure.

### DIFF
--- a/lib/geminabox/proxy/copier.rb
+++ b/lib/geminabox/proxy/copier.rb
@@ -21,7 +21,12 @@ module Geminabox
       end
 
       def get_remote
-        File.open(proxy_path, 'w'){|f| f.write(remote_content)}
+        begin
+          File.open(proxy_path, 'w'){|f| f.write(remote_content)}
+        rescue
+          File.unlink(proxy_path) if File.exists?(proxy_path)
+          raise $!
+        end
       end
 
     end

--- a/test/units/geminabox/proxy/copier_test.rb
+++ b/test/units/geminabox/proxy/copier_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'minitest/mock'
 
 module Geminabox
   module Proxy
@@ -6,6 +7,17 @@ module Geminabox
 
       def setup
         clean_data_dir
+      end
+
+      def test_remote_content_failure
+        raise_stub = proc { puts caller.join("\n") ; raise }
+        copier.stub :remote_content, raise_stub do
+          begin
+            copier.get_remote
+          rescue
+          end
+          assert(!File.exists?(copier.proxy_path), "Cached file should not exist")
+        end
       end
 
       def test_with_no_files_in_place


### PR DESCRIPTION
In case of failure accessing a remote server, Geminabox::Proxy::Copier#get_remote will leave an empty file in the disk. The first call will get HTTP 500, second on, will get 200, with this cached (invalid) empty file. This begin/ensure block deletes the file in case of failure, and raises the original exception.