### PR TITLE
Move content-type into header as required by latest version of webmock

### DIFF
--- a/test/units/geminabox/rubygems_dependency_test.rb
+++ b/test/units/geminabox/rubygems_dependency_test.rb
@@ -11,7 +11,7 @@ module Geminabox
 
     def test_get_list
       stub_request(:get, "https://bundler.rubygems.org/api/v1/dependencies.json?gems=some_gem,other_gem").
-        to_return(:status => 200, :body => some_gem_dependencies.to_json, :headers => {}, :content_type => 'application/json')
+        to_return(:status => 200, :body => some_gem_dependencies.to_json, :headers => {"Content-Type" => 'application/json'})
 
       assert_equal some_gem_dependencies, RubygemsDependency.for(:some_gem, :other_gem)
     end


### PR DESCRIPTION
Current master test runs result in this error:

```
  1) Error:
Geminabox::RubyGemDependencyTest#test_get_list:
ArgumentError: Unknown key: "content_type". Valid keys are: "headers", "status", "body", "exception", "should_timeout"
    /Users/kerrimiller/.rvm/gems/ruby-1.9.3-p551/gems/webmock-1.21.0/lib/webmock/util/hash_validator.rb:12:in `block in validate_keys'
    /Users/kerrimiller/.rvm/gems/ruby-1.9.3-p551/gems/webmock-1.21.0/lib/webmock/util/hash_validator.rb:10:in `each_key'
    /Users/kerrimiller/.rvm/gems/ruby-1.9.3-p551/gems/webmock-1.21.0/lib/webmock/util/hash_validator.rb:10:in `validate_keys'
    /Users/kerrimiller/.rvm/gems/ruby-1.9.3-p551/gems/webmock-1.21.0/lib/webmock/response.rb:80:in `options='
    /Users/kerrimiller/.rvm/gems/ruby-1.9.3-p551/gems/webmock-1.21.0/lib/webmock/response.rb:25:in `initialize'
    /Users/kerrimiller/.rvm/gems/ruby-1.9.3-p551/gems/webmock-1.21.0/lib/webmock/response.rb:15:in `new'
    /Users/kerrimiller/.rvm/gems/ruby-1.9.3-p551/gems/webmock-1.21.0/lib/webmock/response.rb:15:in `response_for'
    /Users/kerrimiller/.rvm/gems/ruby-1.9.3-p551/gems/webmock-1.21.0/lib/webmock/request_stub.rb:21:in `block in to_return'
    /Users/kerrimiller/.rvm/gems/ruby-1.9.3-p551/gems/webmock-1.21.0/lib/webmock/request_stub.rb:21:in `map'
    /Users/kerrimiller/.rvm/gems/ruby-1.9.3-p551/gems/webmock-1.21.0/lib/webmock/request_stub.rb:21:in `to_return'
    /Users/kerrimiller/projects/geminabox/test/units/geminabox/rubygems_dependency_test.rb:13:in `test_get_list'
```

This is because webmock changed its syntax without providing backwards compatibility. This change fixes this error and allows test suite on master to run cleanly.