### PR TITLE
Use Fixnum code for errors

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -48,7 +48,8 @@ module Geminabox
       :http_adapter,
       :lockfile,
       :retry_interval,
-      :allow_remote_failure
+      :allow_remote_failure,
+      :ruby_gems_url
     )
 
     def set_defaults(defaults)
@@ -80,7 +81,8 @@ module Geminabox
     http_adapter:         HttpClientAdapter.new,
     lockfile:             '/tmp/geminabox.lockfile',
     retry_interval:       60,
-    allow_remote_failure: false
+    allow_remote_failure: false,
+    ruby_gems_url:        'https://rubygems.org/'
   )
     
 end

--- a/lib/geminabox/gem_store_error.rb
+++ b/lib/geminabox/gem_store_error.rb
@@ -6,7 +6,7 @@ module Geminabox
     include Nesty::NestedError
 
     def initialize(code, reason)
-      @code = code.to_s
+      @code = code
       @reason = reason
     end
   end

--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -59,7 +59,7 @@ module Geminabox
         file = File.expand_path(File.join(Server.data, *request.path_info))
 
         unless File.exists?(file)
-          ruby_gems_url = 'http://production.cf.rubygems.org'
+          ruby_gems_url = Geminabox.ruby_gems_url
           path = File.join(ruby_gems_url, *request.path_info)
           content = Geminabox.http_adapter.get_content(path)
           GemStore.create(IncomingGem.new(StringIO.new(content)))

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -18,7 +18,8 @@ module Geminabox
       :allow_delete,
       :lockfile,
       :retry_interval,
-      :rubygems_proxy
+      :rubygems_proxy,
+      :ruby_gems_url
     )
 
     if Server.rubygems_proxy

--- a/test/units/geminabox/gem_store_error_test.rb
+++ b/test/units/geminabox/gem_store_error_test.rb
@@ -7,7 +7,7 @@ module Geminabox
       begin
         raise GemStoreError.new(500, reason)
       rescue GemStoreError => error
-        assert_equal(code.to_s, error.code)
+        assert_equal(code, error.code)
         assert_equal(reason, error.reason)
       end
     end

--- a/test/units/geminabox/gem_store_test.rb
+++ b/test/units/geminabox/gem_store_test.rb
@@ -9,7 +9,7 @@ module Geminabox
     def test_prepare_data_folders_with_data_as_file
       Geminabox.data = File.join(__FILE__)
       gem_store = GemStore.new(gem_file(:example))
-      assert_gem_store_error('500', 'is a directory') do
+      assert_gem_store_error(500, 'is a directory') do
         gem_store.prepare_data_folders
       end
     end
@@ -17,7 +17,7 @@ module Geminabox
     def test_prepare_data_folders_with_data_as_unwriteable_folder
       Geminabox.data = '/'
       gem_store = GemStore.new(gem_file(:example))
-      assert_gem_store_error('500', 'is writable') do
+      assert_gem_store_error(500, 'is writable') do
         gem_store.prepare_data_folders
       end
     end
@@ -35,7 +35,7 @@ module Geminabox
     def test_ensure_gem_valid
       invalid_gem = Geminabox::IncomingGem.new(StringIO.new('NOT A GEM'))
       gem_file = GemStore.new invalid_gem
-      assert_gem_store_error('400', 'Cannot process gem') do
+      assert_gem_store_error(400, 'Cannot process gem') do
         gem_file.ensure_gem_valid
       end
     end

--- a/test/units/geminabox/proxy/splicer_test.rb
+++ b/test/units/geminabox/proxy/splicer_test.rb
@@ -51,7 +51,7 @@ module Geminabox
         assert_equal expected, splice.local_path
       end
 
-      def test_local_file_path
+      def test_splice_file_path
         expected = File.expand_path(file_name, File.join(Geminabox::Server.data, 'proxy'))
         assert_equal expected, splice.splice_path
       end


### PR DESCRIPTION
Sinatra relies on the code sent to `#halt` being a Fixnum. If it is not, it sends the status code as a part of the body, for example:
```
409Updating an existing gem is not permitted.
You should either delete the existing version, or change your version number.
```
The above is the HTTP response body received when trying to re-upload a gem version, without the overwrite flag set. The status of the HTTP response is `200`, whereas it should be `409`.