### PR TITLE
Change ruby_gems_url

### DIFF
--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -59,7 +59,7 @@ module Geminabox
         file = File.expand_path(File.join(Server.data, *request.path_info))
 
         unless File.exists?(file)
-          ruby_gems_url = 'http://production.cf.rubygems.org'
+          ruby_gems_url = 'https://rubygems.global.ssl.fastly.net'
           path = File.join(ruby_gems_url, *request.path_info)
           content = Geminabox.http_adapter.get_content(path)
           GemStore.create(IncomingGem.new(StringIO.new(content)))


### PR DESCRIPTION
http://production.cf.rubygems.org/gems/gem-name returns NOT FOUND.
(Rubygems.org is using faslty currently.)

So, ruby_gems_url changes to https://rubygems.global.ssl.fastly.net.