### PR TITLE
proxy: use https://rubygems.org as default upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ bundler_args: --without development
 rvm:
   - 1.9.3
   - 2.0.0
-sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ bundler_args: --without development
 rvm:
   - 1.9.3
   - 2.0.0
+sudo: false

--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -5,7 +5,7 @@ module Geminabox
   module Proxy
     class Hostess < Sinatra::Base
       attr_accessor :file_handler
-      
+
       def serve
         if file_handler
           send_file file_handler.proxy_path
@@ -59,7 +59,7 @@ module Geminabox
         file = File.expand_path(File.join(Server.data, *request.path_info))
 
         unless File.exists?(file)
-          ruby_gems_url = 'http://production.cf.rubygems.org'
+          ruby_gems_url = 'https://rubygems.org'
           path = File.join(ruby_gems_url, *request.path_info)
           content = Geminabox.http_adapter.get_content(path)
           GemStore.create(IncomingGem.new(StringIO.new(content)))


### PR DESCRIPTION
Rather than specify a default CDN, use https://rubygems.org to let rubygems decide which proxy we should use.