### PR TITLE
Adding 'ruby_gems_url' server configuration option

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -48,7 +48,8 @@ module Geminabox
       :http_adapter,
       :lockfile,
       :retry_interval,
-      :allow_remote_failure
+      :allow_remote_failure,
+      :ruby_gems_url
     )
 
     def set_defaults(defaults)
@@ -80,7 +81,8 @@ module Geminabox
     http_adapter:         HttpClientAdapter.new,
     lockfile:             '/tmp/geminabox.lockfile',
     retry_interval:       60,
-    allow_remote_failure: false
+    allow_remote_failure: false,
+    ruby_gems_url:        'http://production.cf.rubygems.org/'
   )
     
 end

--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -59,7 +59,7 @@ module Geminabox
         file = File.expand_path(File.join(Server.data, *request.path_info))
 
         unless File.exists?(file)
-          ruby_gems_url = 'http://production.cf.rubygems.org'
+          ruby_gems_url = Geminabox.ruby_gems_url
           path = File.join(ruby_gems_url, *request.path_info)
           content = Geminabox.http_adapter.get_content(path)
           GemStore.create(IncomingGem.new(StringIO.new(content)))

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -18,7 +18,8 @@ module Geminabox
       :allow_delete,
       :lockfile,
       :retry_interval,
-      :rubygems_proxy
+      :rubygems_proxy,
+      :ruby_gems_url
     )
 
     if Server.rubygems_proxy


### PR DESCRIPTION
This change makes it possible to specify an alternate gem server in config.ru via the 'Geminabox.ruby_gems_url' configuration option.  If not specified, it reverts to the default gem server 'http://production.cf.rubygems.org'.

We ran into an instance yesterday where the hard-coded gem repository (http://production.cf.rubygems.org) in hostess.rb was having issues (returning 404s for gems that should have been there), and thus we couldn't proxy gem requests to the remote gem server.  I was able to resolve the issues by changing the hard-coded gem server URL to 'https://rubygems.org'.