### PR TITLE
Performance improvement

### DIFF
--- a/lib/geminabox/gem_list_merge.rb
+++ b/lib/geminabox/gem_list_merge.rb
@@ -2,6 +2,8 @@ module Geminabox
   class GemListMerge
     attr_accessor :list
 
+    IGNORE_DEPENDENCIES = 0..-2
+
     def self.from(*lists)
       lists.map{|list| new(list)}.inject(:merge)
     end
@@ -11,40 +13,10 @@ module Geminabox
     end
 
     def merge(other)
-      combine_hashes(other).values.flatten.sort do |x, y|
-        x.values[ignore_dependencies] <=> y.values[ignore_dependencies]
-      end
-    end
-
-    def hash
-      list.each do |item|
-        ensure_symbols_as_keys(item)
-        name = item[:name].to_sym
-        collection[name] ||= []
-        collection[name] << item unless collection[name].include?(item)
-      end
-      collection
-    end
-
-    def collection
-      @collection ||= {}
-    end
-
-    def combine_hashes(other)
-      hash.merge(other.hash) do |key, value, other_value|
-        (value + other_value).uniq{|v| v.values[ignore_dependencies]}
-      end
-    end
-
-    def ignore_dependencies
-      0..-2
-    end
-
-    def ensure_symbols_as_keys(item)
-      item.keys.each do |key|
-        next if key.kind_of? Symbol
-        item[key.to_sym] = item.delete(key)
-      end
+      merged = (list + other.list)
+      merged.uniq! {|val| val.values[IGNORE_DEPENDENCIES] }
+      merged.sort_by! {|x| x.values[IGNORE_DEPENDENCIES] }
+      merged
     end
 
   end

--- a/lib/geminabox/http_adapter/http_client_adapter.rb
+++ b/lib/geminabox/http_adapter/http_client_adapter.rb
@@ -25,7 +25,10 @@ module Geminabox
     end
 
     def http_client
-      @http_client ||= HTTPClient.new(ENV['http_proxy'])
+      @http_client ||= HTTPClient.new(ENV['http_proxy']).tap {|client|
+        client.transparent_gzip_decompression = true
+        client.keep_alive_timeout = 32 # sec
+      }
     end
 
   end

--- a/lib/geminabox/rubygems_dependency.rb
+++ b/lib/geminabox/rubygems_dependency.rb
@@ -13,14 +13,14 @@ module Geminabox
           gems.map(&:to_s).join(',')
         ].join
         body = Geminabox.http_adapter.get_content(url)
-        JSON.parse(body)
+        Marshal.load(body)
       rescue Exception => e
         return [] if Geminabox.allow_remote_failure
         raise e
       end
 
       def rubygems_uri
-        "https://bundler.rubygems.org/api/v1/dependencies.json"
+        "https://bundler.rubygems.org/api/v1/dependencies"
       end
 
     end

--- a/test/units/geminabox/gem_list_merge_test.rb
+++ b/test/units/geminabox/gem_list_merge_test.rb
@@ -30,13 +30,6 @@ module Geminabox
       assert_equal expected, GemListMerge.from(list_one, list_two)
     end
 
-    def test_merge_with_text_keys
-      list_one = gem_list [:c], [:a]
-      list_two = [build_text_gem(:b)]
-      expected = gem_list [:a], [:b], [:c]
-      assert_equal expected, GemListMerge.from(list_one, list_two)
-    end
-
     def test_merge_ignores_dependencies
       list_one = gem_list [:a]
       list_two = gem_list [:a]
@@ -50,20 +43,6 @@ module Geminabox
       list_two = []
       expected = gem_list [:a], [:b]
       assert_equal expected, GemListMerge.from(list_one, list_two)
-    end
-
-    def test_hash
-      assert_equal [:x, :y], gem_list_merge.hash.keys
-      assert_equal [build_gem(:x)], gem_list_merge.hash[:x]
-    end
-
-    def build_text_gem(name, number = '0.0.1')
-      {
-          'name' => name.to_s,
-          'number' => number,
-          'platform' => 'ruby',
-          'dependencies' => []
-      }
     end
 
     def build_gem(name, number = '0.0.1')

--- a/test/units/geminabox/rubygems_dependency_test.rb
+++ b/test/units/geminabox/rubygems_dependency_test.rb
@@ -10,14 +10,14 @@ module Geminabox
     end
 
     def test_get_list
-      stub_request(:get, "https://bundler.rubygems.org/api/v1/dependencies.json?gems=some_gem,other_gem").
-        to_return(:status => 200, :body => some_gem_dependencies.to_json, :headers => {"Content-Type" => 'application/json'})
+      stub_request(:get, "https://bundler.rubygems.org/api/v1/dependencies?gems=some_gem,other_gem").
+        to_return(:status => 200, :body => Marshal.dump(some_gem_dependencies), :headers => {"Content-Type" => 'application/octet-stream'})
 
       assert_equal some_gem_dependencies, RubygemsDependency.for(:some_gem, :other_gem)
     end
 
     def test_get_list_with_500_error
-      stub_request(:get, "https://bundler.rubygems.org/api/v1/dependencies.json?gems=some_gem,other_gem").
+      stub_request(:get, "https://bundler.rubygems.org/api/v1/dependencies?gems=some_gem,other_gem").
         to_return(:status => 500, :body => 'Whoops')
 
       assert_raises HTTPClient::BadResponseError do
@@ -26,7 +26,7 @@ module Geminabox
     end
 
     def test_get_list_with_401_error
-      stub_request(:get, "https://bundler.rubygems.org/api/v1/dependencies.json?gems=some_gem,other_gem").
+      stub_request(:get, "https://bundler.rubygems.org/api/v1/dependencies?gems=some_gem,other_gem").
         to_return(:status => 401, :body => 'Whoops')
       assert_raises HTTPClient::BadResponseError do
         RubygemsDependency.for(:some_gem, :other_gem)
@@ -43,7 +43,7 @@ module Geminabox
     end
 
     def test_get_list_with_500_error_and_allow_remote_failure
-      stub_request(:get, "https://bundler.rubygems.org/api/v1/dependencies.json?gems=some_gem,other_gem").
+      stub_request(:get, "https://bundler.rubygems.org/api/v1/dependencies?gems=some_gem,other_gem").
         to_return(:status => 500, :body => 'Whoops')
 
       Geminabox.allow_remote_failure = true
@@ -51,7 +51,7 @@ module Geminabox
     end
 
     def test_get_list_with_401_error_and_allow_remote_failure
-      stub_request(:get, "https://bundler.rubygems.org/api/v1/dependencies.json?gems=some_gem,other_gem").
+      stub_request(:get, "https://bundler.rubygems.org/api/v1/dependencies?gems=some_gem,other_gem").
         to_return(:status => 401, :body => 'Whoops')
 
       Geminabox.allow_remote_failure = true


### PR DESCRIPTION
This PR includes 3 improvements for performance. 

## 1. Use /api/v1/dependencies

`api/v1/dependencies` returns marshal dump. `api/v1/dependencies.json` returns JSON contents. The former is faster. We should use the former.

```
marshal_url: 1.261804 sec
json_url: 2.01807 sec
```

as an example to resolve dependencies for `rake,flexmock,parallel_tests,simplecov,rr,timecop,test-unit,test-unit-rr,oj,pry,pry-nav,fluent-plugin-s3,fluent-plugin-forest,fluent-plugin-record-reformer,msgpack,json,yajl-ruby,cool.io,http_parser.rb,sigdump,tzinfo,tzinfo-data,strptime`. You can see detail with this commit https://github.com/geminabox/geminabox/pull/230/commits/41e06f716159d3849cd3c330326ba873345ffec9

## 2. Speed up gem_list_merge

```
BEFORE: 0.20931879 sec
AFTER: 0.047801906 sec
```

to resolve dependencies for `activemodel,arel,tzinfo,activerecord-deprecated_finders,i18n,multi_json,minitest,thread_safe,concurrent-ruby,method_source,term-ansicolor,treetop,gherkin,polyglot,json_pure,multi_test,cucumber-core,gherkin3,cucumber-wire,event-bus,bones,net-scp,metaclass,rspec-support`. You can see a detail with this commit https://github.com/geminabox/geminabox/commit/e53e4682669aca1c627fedf357192c118d8e5a01.

EDIT: I could improve more  using sort_by! instead of sort! https://github.com/geminabox/geminabox/pull/230/commits/39f5b2ff29be21895285c00654c73981b3750271

```
BEFORE: 1.10931879 sec
AFTER: 0.047122157
```

to resolve dependencies for
`bones,rcov,rspec,rubyforge,ZenTest,addressable,multipart-post,faraday,faraday-middleware,httpauth,jwt,multi_xml,jar-dependencies,ffi,rbnacl,curses,launchy,bones-rcov,bones-rspec,bones-rubyforge,bones-zentest,git,functional-ruby,ref,gherkin,gherkin3,trollop,term-ansicolor,hashie,oauth2,nokogiri,termios,json_pure,RubyInline,metaclass,needle,echoe,jruby-pageant,bcrypt_pbkdf,rbnacl-libsodium,minitest,psych,tins,facets,polyglot,unf_ext,sexp_processor,concurrent-ruby,method_source,jamespath`

## 3. Set Accept-Encoding: gzip

https://github.com/geminabox/geminabox/pull/230/commits/2ffcafe7f5cab3aee8c26f617d6619122db2f94a

`https://bundler.rubygems.org/api/v1/dependencies` accepts gzip encoding. Using gzip encoding was faster based on experiments. 

```
BEFORE: 1.454 sec
AFTER: 1.116 sec
```

to resolve dependencies for `unicorn,rake,server-starter,oneline_log_formatter,sinatra,builder,httpclient,nesty,faraday`
