### PR TITLE
Add incremental option to reindex route

### DIFF
--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -53,6 +53,7 @@ module Geminabox
           begin
             require 'geminabox/indexer'
             updated_gemspecs = Geminabox::Indexer.updated_gemspecs(indexer)
+            return if updated_gemspecs.empty?
             Geminabox::Indexer.patch_rubygems_update_index_pre_1_8_25(indexer)
             indexer.update_index
             updated_gemspecs.each { |gem| dependency_cache.flush_key(gem.name) }
@@ -107,7 +108,11 @@ module Geminabox
 
     get '/reindex' do
       serialize_update do
-        self.class.reindex(:force_rebuild)
+        if params[:incremental] == 'true'
+          self.class.reindex
+        else
+          self.class.reindex(:force_rebuild)
+        end
         redirect url("/")
       end
     end

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -109,6 +109,9 @@ module Geminabox
     get '/reindex' do
       serialize_update do
         params[:force_rebuild] ||= 'true'
+        unless %w(true false).include? params[:force_rebuild]
+          error_response(400, "force_rebuild parameter must be either of true or false, but was #{params[:force_rebuild]}")
+        end
         force_rebuild = params[:force_rebuild] == 'true'
         self.class.reindex(force_rebuild)
         redirect url("/")

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -108,11 +108,8 @@ module Geminabox
 
     get '/reindex' do
       serialize_update do
-        if params[:incremental] == 'true'
-          self.class.reindex
-        else
-          self.class.reindex(:force_rebuild)
-        end
+        force_rebuild = params[:incremental] != 'true'
+        self.class.reindex(force_rebuild)
         redirect url("/")
       end
     end

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -108,7 +108,8 @@ module Geminabox
 
     get '/reindex' do
       serialize_update do
-        force_rebuild = params[:incremental] != 'true'
+        params[:force_rebuild] ||= 'true'
+        force_rebuild = params[:force_rebuild] == 'true'
         self.class.reindex(force_rebuild)
         redirect url("/")
       end


### PR DESCRIPTION
I would like to add an option to perform an incremental reindex.

We have multiple servers running and they share an s3 mounted gems directory. The cache that gets generated when creating the index can be a little slow as it appears to need to read all the gems in the gems directory. However, the incremental index appears to only check for new gems and only indexes those.

Because gems might be added from a different server to the s3 bucket, this will allow us to more efficiently reindex the rest of the servers without needing to update the entire gem index.

```
curl localhost:9292/reindex?incremental=true
```

Also, I noticed an error if I performed incremental updates twice in a row when there were no new gemspecs found so I added an early return.