### PR TITLE
Atomic writes proxy latest specs

### DIFF
--- a/lib/geminabox/proxy/file_handler.rb
+++ b/lib/geminabox/proxy/file_handler.rb
@@ -9,7 +9,7 @@ module Geminabox
         @file_name = file_name
         ensure_destination_exists
       end
-      
+
       def local_path
         File.expand_path(file_name, root_path)
       end
@@ -21,7 +21,7 @@ module Geminabox
       def local_file_exists?
         file_exists? local_path
       end
-      
+
       def proxy_file_exists?
         file_exists? proxy_path
       end

--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -5,7 +5,6 @@ module Geminabox
   module Proxy
     class Hostess < Sinatra::Base
       attr_accessor :file_handler
-      
       def serve
         if file_handler
           send_file file_handler.proxy_path

--- a/lib/geminabox/proxy/splicer.rb
+++ b/lib/geminabox/proxy/splicer.rb
@@ -1,8 +1,9 @@
+require 'tempfile'
 
 module Geminabox
   module Proxy
     class Splicer < FileHandler
-      
+
       def self.make(file_name)
         splicer = new(file_name)
         splicer.create
@@ -10,7 +11,16 @@ module Geminabox
       end
 
       def create
-        File.open(splice_path, 'w'){|f| f.write(new_content)}
+        data = new_content
+        return nil if data.nil?
+        begin
+          tmp = Tempfile.new('geminabox')
+          File.open(tmp, 'w'){|f| f.write(data)}
+        rescue
+          return nil
+        end
+
+        FileUtils.mv tmp, splice_path
       end
 
       def new_content

--- a/lib/geminabox/version.rb
+++ b/lib/geminabox/version.rb
@@ -1,3 +1,3 @@
 module Geminabox
-  VERSION = '0.13.1' unless defined? VERSION
+  VERSION = '0.13.2' unless defined? VERSION
 end


### PR DESCRIPTION
I believe we are hitting the same race condition that was reported in https://github.com/geminabox/geminabox/issues/202

This PR should fix that race condition by creating a temporary file for the latest_specs and then doing an atomic move.

I have been running this for a few weeks and it solved the issues we had, everything seems to work smoothly.