### PR TITLE
Fix sinatra version to still working with ruby 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.13.6 (2017-05-24)
+
+Fixes:
+
+* Restricts sinatra version to avoid incompatibility with ruby versions < 2.2.2.
+
 # 0.13.5 (2017-01-14)
 
 Fixes:

--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files             = %w[MIT-LICENSE README.md] + Dir['{lib,public,views}/**/*']
   s.require_paths     = ['lib']
 
-  s.add_dependency('sinatra', [">= 1.2.7"])
+  s.add_dependency('sinatra', [">= 1.2.7", "< 2.0.0"])
   s.add_dependency('builder')
   s.add_dependency('httpclient', [">= 2.2.7"])
   s.add_dependency('nesty')

--- a/lib/geminabox/version.rb
+++ b/lib/geminabox/version.rb
@@ -1,3 +1,3 @@
 module Geminabox
-  VERSION = '0.13.5' unless defined? VERSION
+  VERSION = '0.13.6' unless defined? VERSION
 end


### PR DESCRIPTION
In ruby 2.1, when running `bundle install` was returning the error:
Gem::InstallError: rack requires Ruby version >= 2.2.2.
An error occurred while installing rack (2.0.3), and Bundler cannot continue.