### PR TITLE
Concurrent reindex(:force_rebuild) should be serialized

### DIFF
--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency('httpclient', [">= 2.2.7"])
   s.add_dependency('nesty')
   s.add_dependency('faraday')
+  s.add_dependency('reentrant_flock')
 end

--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -13,7 +13,6 @@ require 'tilt/erb'
 module Geminabox
 
   class Error < StandardError ; end
-  class AlreadyLocked < Error ; end
 
   require_relative 'geminabox/version'
   require_relative 'geminabox/proxy'

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -63,11 +63,11 @@ module Geminabox
             indexer.update_index
             updated_gemspecs.each { |gem| dependency_cache.flush_key(gem.name) }
           rescue Errno::ENOENT
-            reindex(:force_rebuild)
+            with_lock { reindex(:force_rebuild) }
           rescue => e
             puts "#{e.class}:#{e.message}"
             puts e.backtrace.join("\n")
-            reindex(:force_rebuild)
+            with_lock { reindex(:force_rebuild) }
           end
         end
       rescue Gem::SystemExitException

--- a/test/units/geminabox/server_test.rb
+++ b/test/units/geminabox/server_test.rb
@@ -15,11 +15,12 @@ module Geminabox
       attr_reader :mock_file
 
       def initialize(flock_return)
-        @mock_file = Minitest::Mock.new
-        mock_file.expect(:flock, flock_return, [File::LOCK_EX | File::LOCK_NB])
+        @mock_file = Object.new
+        mock_file.define_singleton_method(:flock) {|operator| flock_return }
       end
 
       def open(name, mode)
+        mock_file.define_singleton_method(:path) { name }
         yield mock_file
       end
     end
@@ -31,7 +32,7 @@ module Geminabox
         @server = Geminabox::Server.new.instance_variable_get(:@instance)
         # ivar for the tests.  Local variable for the define_method.  <sigh>
         fake_file_class = @fake_file_class = klass.new(flock_return)
-        server.singleton_class.send(:define_method, :file_class){ fake_file_class }
+        Geminabox::Server.file_class = fake_file_class
         @mock_file = fake_file_class.mock_file
       end
     end
@@ -39,25 +40,20 @@ module Geminabox
     def teardown
       Geminabox.http_adapter = HttpClientAdapter.new
       Geminabox.allow_remote_failure = false
+      Geminabox::Server.file_class = File
     end
 
-    describe "#with_lock" do
+    describe "#with_reentrant_lock" do
       include PrepServer
 
       def do_call
-        server.send(:with_lock) { @called = true }
+        server.send(:with_reentrant_lock) { @called = true }
       end
 
       def test_it_yields
         prep_server(FileOpenYields, true)
         do_call
         assert_equal true, @called
-      end
-
-      def test_it_calls_flock_on_the_yielded_value_exclusive_nonblocking
-        prep_server(FileOpenYields, true)
-        do_call
-        assert mock_file.verify
       end
 
       def test_it_blows_up_if_it_cannot_obtain_lock
@@ -83,8 +79,8 @@ module Geminabox
         end
       end
 
-      def test_block_passed_to_with_lock
-        def @server.with_lock(&block)
+      def test_block_passed_to_with_reentrant_lock
+        def @server.with_reentrant_lock(&block)
           @args = block
         end
 
@@ -93,8 +89,8 @@ module Geminabox
         assert_equal blk, @server.args
       end
 
-      def test_alreadylocked_in_with_lock_invokes_halt
-        def @server.with_lock(&block)
+      def test_alreadylocked_in_with_reentrant_lock_invokes_halt
+        def @server.with_reentrant_lock(&block)
           raise ReentrantFlock::AlreadyLocked
         end
 

--- a/test/units/geminabox/server_test.rb
+++ b/test/units/geminabox/server_test.rb
@@ -62,7 +62,7 @@ module Geminabox
 
       def test_it_blows_up_if_it_cannot_obtain_lock
         prep_server(FileOpenYields, false)
-        assert_raises(AlreadyLocked) { do_call }
+        assert_raises(ReentrantFlock::AlreadyLocked) { do_call }
       end
 
       def test_it_calls_File_open_with_correct_args
@@ -93,9 +93,9 @@ module Geminabox
         assert_equal blk, @server.args
       end
 
-      def test_AlreadyLocked_in_with_lock_invokes_halt
+      def test_alreadylocked_in_with_lock_invokes_halt
         def @server.with_lock(&block)
-          raise AlreadyLocked
+          raise ReentrantFlock::AlreadyLocked
         end
 
         def @server.halt(code, headers, message)

--- a/test/units/geminabox/server_test.rb
+++ b/test/units/geminabox/server_test.rb
@@ -43,11 +43,11 @@ module Geminabox
       Geminabox::Server.file_class = File
     end
 
-    describe "#with_reentrant_lock" do
+    describe "#with_rlock" do
       include PrepServer
 
       def do_call
-        server.send(:with_reentrant_lock) { @called = true }
+        server.send(:with_rlock) { @called = true }
       end
 
       def test_it_yields
@@ -79,8 +79,8 @@ module Geminabox
         end
       end
 
-      def test_block_passed_to_with_reentrant_lock
-        def @server.with_reentrant_lock(&block)
+      def test_block_passed_to_with_rlock
+        def @server.with_rlock(&block)
           @args = block
         end
 
@@ -89,8 +89,8 @@ module Geminabox
         assert_equal blk, @server.args
       end
 
-      def test_alreadylocked_in_with_reentrant_lock_invokes_halt
-        def @server.with_reentrant_lock(&block)
+      def test_alreadylocked_in_with_rlock_invokes_halt
+        def @server.with_rlock(&block)
           raise ReentrantFlock::AlreadyLocked
         end
 


### PR DESCRIPTION
Otherwise,

* index would be broken.
* geminabox would run out all of CPU cores with CPU usage 100%.
