### PR TITLE
Fix XSS & CSRF vulnerabilities - CVE-2017-14506

### DIFF
--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -297,6 +297,10 @@ HTML
     end
 
     helpers do
+      def h(text)
+        Rack::Utils.escape_html(text)
+      end
+
       def spec_for(gem_name, version, platform = default_platform)
         filename = [gem_name, version]
         filename.push(platform) if platform != default_platform

--- a/views/gem.erb
+++ b/views/gem.erb
@@ -27,7 +27,7 @@
           <%= spec.description %>
           <br/>
           <span class="author">– <%= spec.authors.map do |author|
-            "<a href='#{spec.homepage}'>#{author}</a>"
+            "<a href='#{h(spec.homepage)}'>#{author}</a>"
           end.join(', ') %></span>
         <% end %>
         </p>

--- a/views/index.erb
+++ b/views/index.erb
@@ -46,7 +46,7 @@
               <%= spec.description %>
               <br/>
               <span class="author">– <%= spec.authors.map do |author|
-                "<a href='#{spec.homepage}'>#{author}</a>"
+                "<a href='#{h(spec.homepage)}'>#{author}</a>"
               end.join(', ') %></span>
             <% end %>
           </p>


### PR DESCRIPTION
Fix https://github.com/geminabox/geminabox/issues/278

spec.homepage and spec.email needs to be htmlescaped
(others such as spec.authors are already escaped), and
the spec.homepage is used on geminabox view.