### PR TITLE
Make Rack::Session::Pool's expire_after be smaller to save memory

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -52,7 +52,8 @@ module Geminabox
       :allow_remote_failure,
       :ruby_gems_url,
       :bundler_ruby_gems_url,
-      :allow_upload
+      :allow_upload,
+      :session_expire_after,
     )
 
     def set_defaults(defaults)
@@ -87,7 +88,8 @@ module Geminabox
     allow_remote_failure:  false,
     ruby_gems_url:         'https://rubygems.org/',
     bundler_ruby_gems_url: 'https://bundler.rubygems.org/',
-    allow_upload:          true
+    allow_upload:          true,
+    session_expire_after:  1000, # sec
   )
     
 end

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -4,7 +4,7 @@ module Geminabox
 
   class Server < Sinatra::Base
     enable :static, :methodoverride
-    use Rack::Session::Pool, :expire_after => 2592000
+    use Rack::Session::Pool, :expire_after => Geminabox.session_expire_after
     use Rack::Protection
 
     def self.delegate_to_geminabox(*delegate_methods)


### PR DESCRIPTION
and make the number be configurable