### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
-FROM ruby:2.3.0-onbuild
-RUN mkdir data
+FROM ruby:2.4.3
+
+RUN bundle config --global frozen 1
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app
+RUN bundle install
+
 EXPOSE 9292
 
 ENTRYPOINT ["rackup", "--host", "0.0.0.0"]


### PR DESCRIPTION
Problem
====

The Dockerfile does not work currently. Because the ruby-onbuild image does not work with a gemspec. See https://github.com/docker-library/ruby/issues/22

```
$ docker build -t geminabox .
Sending build context to Docker daemon  880.1kB
Step 1/4 : FROM ruby:2.3.0-onbuild
 ---> Using cache
 ---> Using cache
 ---> Running in 926fd054cc66

[!] There was an error parsing `Gemfile`: There are no gemspecs at /usr/src/app. Bundler cannot continue.

 #  from /usr/src/app/Gemfile:3
 #  -------------------------------------------
 #
 >  gemspec
 #  group :development do
 #  -------------------------------------------
```

Solution
====

Use ruby (without "onbuild") image instead.
The `Dockerfile` inherits `ruby:2.4.3`, and the file content bases `ruby-onbuild`.
https://github.com/docker-library/ruby/blob/a6918175fd506b46bf2d8f899f4faa40e72296fb/2.3/jessie/onbuild/Dockerfile

In the `Dockerfile`, it copies app files into a docker container before `bundle install` to avoid the problem.

Note
===

This change updates Ruby version from 2.3.0 to 2.4.3. I guess 2.4.3 is latest supported version (See https://github.com/geminabox/geminabox/blob/50e0253478b16fa8cc4ea5f88359447ede022869/.travis.yml ).