### PR TITLE
Update rubygems call to gunzip/inflate

### DIFF
--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -243,7 +243,7 @@ HTML
     def all_gems_with_duplicates
       specs_files_paths.map do |specs_file_path|
         if File.exist?(specs_file_path)
-          Marshal.load(Gem.gunzip(Gem.read_binary(specs_file_path)))
+          Marshal.load(Gem::Util.gunzip(Gem.read_binary(specs_file_path)))
         else
           []
         end
@@ -311,7 +311,7 @@ HTML
         spec_file = File.join(Geminabox.data, "quick", "Marshal.#{Gem.marshal_version}", "#{filename.join("-")}.gemspec.rz")
         File::open(spec_file, 'r') do |unzipped_spec_file|
           unzipped_spec_file.binmode
-          Marshal.load(Gem.inflate(unzipped_spec_file.read))
+          Marshal.load(Gem::Util.inflate(unzipped_spec_file.read))
         end if File.exist? spec_file
       end
 


### PR DESCRIPTION
Gem.gunzip/inflate have been deprecated in favour of Gem::Util.gunzip/inflate 

(https://github.com/rubygems/rubygems/blob/master/lib/rubygems/util.rb)