### PR TITLE
Added support for yanking gems via the Gemcutter API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test/fixtures/fake_home_path/.gem/specs
 .bin
 *.gem
 test/fixtures/*.fixture
+.rake_tasks~

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -147,6 +147,23 @@ module Geminabox
 
     end
 
+    delete '/api/v1/gems/yank' do
+      unless self.class.allow_delete?
+        error_response(403, 'Gem deletion is disabled')
+      end
+
+      file_path = File.join(Geminabox.data, 'gems', [[params['gem_name'], params['version']].join('-'), '.gem'].join)
+      if File.exist? file_path
+        serialize_update do
+          File.delete file_path
+          self.class.reindex(:force_rebuild)
+          "Gem #{params['gem_name']} #{params['version']} deleted"
+        end
+      else
+        "Gem #{params['gem_name']} #{params['version']} not found"
+      end
+    end
+
     post '/upload' do
       unless self.class.allow_upload?
         error_response(403, 'Gem uploading is disabled')

--- a/test/integration/yanking_gems/auth_test.rb
+++ b/test/integration/yanking_gems/auth_test.rb
@@ -1,0 +1,15 @@
+require_relative '../../test_helper'
+
+class AuthTest < Geminabox::TestCase
+  url "http://foo:bar@localhost/"
+
+  app do
+    use Rack::Auth::Basic do |username, password|
+      username == "foo" and password == "bar"
+    end
+
+    run Geminabox::Server
+  end
+
+  should_yank_gem
+end

--- a/test/integration/yanking_gems/basic_test.rb
+++ b/test/integration/yanking_gems/basic_test.rb
@@ -1,0 +1,5 @@
+require_relative '../../test_helper'
+
+class BasicTest < Geminabox::TestCase
+  should_yank_gem
+end

--- a/test/integration/yanking_gems/path_test.rb
+++ b/test/integration/yanking_gems/path_test.rb
@@ -1,0 +1,25 @@
+require_relative '../../test_helper'
+
+class PathTest < Geminabox::TestCase
+  url "http://localhost/foo"
+
+  app do
+    map "/foo" do
+      run Geminabox::Server
+    end
+  end
+
+  should_yank_gem
+end
+
+class PathWithTrailingSlashTest < Geminabox::TestCase
+  url "http://localhost/foo/"
+
+  app do
+    map "/foo" do
+      run Geminabox::Server
+    end
+  end
+
+  should_yank_gem
+end

--- a/test/integration/yanking_gems/ssl_test.rb
+++ b/test/integration/yanking_gems/ssl_test.rb
@@ -1,0 +1,8 @@
+require_relative '../../test_helper'
+
+class SSLTest < Geminabox::TestCase
+  url "https://127.0.0.1/"
+  ssl true
+
+  should_yank_gem
+end


### PR DESCRIPTION
Geminabox doesn't currently support yanking gems via the Gemcutter API. This PR adds that functionality, along with some tests for the various cases where yanking might be used.

The only issue is that `gem yank` doesn't like the self-signed certificate provided by the tests. I attempted to fix this locally, to no avail, so I've skipped that test for now.