### PR TITLE
fix delete action not showing up on gem page if enabled

### DIFF
--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -130,6 +130,7 @@ module Geminabox
     get '/gems/:gemname' do
       gems = Hash[load_gems.by_name]
       @gem = gems[params[:gemname]]
+      @allow_delete = self.class.allow_delete?
       halt 404 unless @gem
       erb :gem
     end


### PR DESCRIPTION
This PR corrects the scenario where the user has allow_delete enabled and wishes to delete from the gem view page.  This behavior was broken with PR #294 
