### PR TITLE
Fix deprecation warning of Gem::Specification#has_rdoc

### DIFF
--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
   s.homepage          = 'http://tomlea.co.uk/p/gem-in-a-box'
   s.metadata          = { "source_code_uri" => "https://github.com/geminabox/geminabox" }
 
-  s.has_rdoc          = true
   s.extra_rdoc_files  = %w[README.md]
   s.rdoc_options      = %w[--main README.md]
 


### PR DESCRIPTION
This following message has been output.

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from geminabox.gemspec:13.
```

Environment:

* Rubygems: 3.0.3
* Ruby: ruby 2.6.2p47 (2019-03-13 revision 67232) [x86_64-linux]
