### PR TITLE
implement index file cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ If you want Geminabox to carry on providing gems when rubygems.org is unavailabl
 
     Geminabox.allow_remote_failure = true
 
+### Index File Caching
+
+If Geminabox is configured to act as a proxy it will download the latest index file and merge it with the local
+index on every request. This may create some serious performance issues if multiple clients are using the service.
+
+To work around this it is possible to activate index file caching. To use it you will need a cache store that is
+compatible with 'cachy' like for example 'moneta' or 'memcached'.
+
+To configure a simple moneta file cache store add the following to the config.ru:
+
+```ruby
+Geminabox.cache_store = Moneta.new(:File, dir: File.join('/path/to/data/dir/_index_cache'), expires: 1800)
+```
+
 ## HTTP adapter
 
 Geminabox uses the HTTPClient gem to manage its connections to remote resources.

--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency('nesty')
   s.add_dependency('faraday')
   s.add_dependency('reentrant_flock')
+  s.add_dependency('cachy')
 end

--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -10,6 +10,7 @@ require 'tempfile'
 require 'json'
 require 'tilt/erb'
 require 'rack/protection'
+require 'cachy'
 
 module Geminabox
 
@@ -53,7 +54,8 @@ module Geminabox
       :ruby_gems_url,
       :bundler_ruby_gems_url,
       :allow_upload,
-      :on_gem_received
+      :on_gem_received,
+      :cache_store,
     )
 
     def set_defaults(defaults)
@@ -66,8 +68,9 @@ module Geminabox
     def settings
       Server.settings
     end
-    
+
     def call(env)
+      Cachy.cache_store = Geminabox.cache_store
       Server.call env
     end
   end
@@ -89,7 +92,7 @@ module Geminabox
     ruby_gems_url:         'https://rubygems.org/',
     bundler_ruby_gems_url: 'https://bundler.rubygems.org/',
     allow_upload:          true,
-    on_gem_received:       nil
+    on_gem_received:       nil,
+    cache_store:           nil,
   )
-    
 end

--- a/lib/geminabox/proxy/file_handler.rb
+++ b/lib/geminabox/proxy/file_handler.rb
@@ -57,6 +57,14 @@ module Geminabox
         File.read(local_path).force_encoding(encoding)
       end
 
+      def mtime
+        File.mtime(local_path)
+      end
+
+      def cache_key
+        "#{file_name} #{mtime}"
+      end
+
       private
       def encoding
         "UTF-8"

--- a/lib/geminabox/proxy/splicer.rb
+++ b/lib/geminabox/proxy/splicer.rb
@@ -7,8 +7,18 @@ module Geminabox
 
       def self.make(file_name)
         splicer = new(file_name)
-        splicer.create
-        splicer
+        cached(:file_handler, splicer) do
+          splicer.create
+          splicer
+        end
+      end
+
+      def self.cached(*args)
+        if Geminabox.cache_store
+          Cachy.cache(*args){ yield }
+        else
+          yield
+        end
       end
 
       def create
@@ -41,6 +51,12 @@ module Geminabox
 
       def splice_file_exists?
         file_exists? splice_path
+      end
+
+      def remote_content
+        Splicer.cached(:remote_content, @file_name) do
+          super
+        end
       end
 
       def merge_content

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -13,6 +13,10 @@ module Geminabox
       use Hostess
     end
 
+    if Geminabox.cache_store
+      Cachy.cache_store = Geminabox.cache_store
+    end
+
     class << self
       def disallow_replace?
         ! Geminabox.allow_replace


### PR DESCRIPTION
We ran into the issue that if geminabox is configured as proxy and multiple clients are connecting the service becomes completely unresponsive as geminabox downloads the index and merges it for every single request.

I implemented some simple caching by using the gem 'cachy' which can use different backend based on the requirements of the deployment. It can simply use moneta with a file store if geminabox is running on a single node or something like memcached if the cache should be shared among multiple nodes.

The implementation is pretty simple and if nothing is configured everything will behave as it currently does.

I'm not sure if this is something you even want to include, but I thought if others have the same issue there is at least a patch available or an idea how this can be solved. We are running this in production for almost a year now and so far we had no issues.