### PR TITLE
fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM ruby:2.4.3
 
-RUN bundle config --global frozen 1
-
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The Dockerfile has `bundle config --global frozen 1`, but there's no Gemfile.lock in the repo. Obviously this is a problem.