### PR TITLE
Prevent "dependency confusion" resulting in a malicious upstream gem taking precedence over a local gem

### DIFF
--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -46,6 +46,7 @@ module Geminabox
       :gem_permissions,
       :allow_delete,
       :rubygems_proxy,
+      :rubygems_proxy_merge_strategy,
       :http_adapter,
       :lockfile,
       :retry_interval,
@@ -73,23 +74,24 @@ module Geminabox
   end
 
   set_defaults(
-    data:                  File.join(File.dirname(__FILE__), *%w[.. data]),
-    public_folder:         File.join(File.dirname(__FILE__), *%w[.. public]),
-    build_legacy:          false,
-    incremental_updates:   true,
-    views:                 File.join(File.dirname(__FILE__), *%w[.. views]),
-    allow_replace:         false,
-    gem_permissions:       0644,
-    rubygems_proxy:        (ENV['RUBYGEMS_PROXY'] == 'true'),
-    allow_delete:          true,
-    http_adapter:          HttpClientAdapter.new,
-    lockfile:              '/tmp/geminabox.lockfile',
-    retry_interval:        60,
-    allow_remote_failure:  false,
-    ruby_gems_url:         'https://rubygems.org/',
-    bundler_ruby_gems_url: 'https://bundler.rubygems.org/',
-    allow_upload:          true,
-    on_gem_received:       nil
+    data:                           File.join(File.dirname(__FILE__), *%w[.. data]),
+    public_folder:                  File.join(File.dirname(__FILE__), *%w[.. public]),
+    build_legacy:                   false,
+    incremental_updates:            true,
+    views:                          File.join(File.dirname(__FILE__), *%w[.. views]),
+    allow_replace:                  false,
+    gem_permissions:                0644,
+    rubygems_proxy:                 (ENV['RUBYGEMS_PROXY'] == 'true'),
+    rubygems_proxy_merge_strategy:  ENV.fetch('RUBYGEMS_PROXY_MERGE_STRATEGY') { :local_gems_take_precedence_over_remote_gems }.to_sym,
+    allow_delete:                   true,
+    http_adapter:                   HttpClientAdapter.new,
+    lockfile:                       '/tmp/geminabox.lockfile',
+    retry_interval:                 60,
+    allow_remote_failure:           false,
+    ruby_gems_url:                  'https://rubygems.org/',
+    bundler_ruby_gems_url:          'https://bundler.rubygems.org/',
+    allow_upload:                   true,
+    on_gem_received:                nil
   )
     
 end

--- a/lib/geminabox/gem_list_merge.rb
+++ b/lib/geminabox/gem_list_merge.rb
@@ -1,23 +1,38 @@
+require "set"
+
 module Geminabox
-  class GemListMerge
-    attr_accessor :list
-
-    IGNORE_DEPENDENCIES = 0..-2
-
-    def self.from(*lists)
-      lists.map{|list| new(list)}.inject(:merge)
+  module GemListMerge
+    def self.merge(local_gem_list, remote_gem_list, strategy:)
+      strategy_for(strategy).merge(local_gem_list, remote_gem_list)
     end
 
-    def initialize(list)
-      @list = list
+    def self.strategy_for(strategy)
+      case strategy
+      when :local_gems_take_precedence_over_remote_gems
+        LocalGemsTakePrecedenceOverRemoteGems
+      when :combine_local_and_remote_gem_versions
+        CombineLocalAndRemoteGemVersions
+      else
+        raise ArgumentError, "Merge strategy must be :local_gems_take_precedence_over_remote_gems (default) or :merge_local_and_remote_gem_versions"
+      end
     end
 
-    def merge(other)
-      merged = (list + other.list)
-      merged.uniq! {|val| val.values[IGNORE_DEPENDENCIES] }
-      merged.sort_by! {|x| x.values[IGNORE_DEPENDENCIES] }
-      merged
+    module LocalGemsTakePrecedenceOverRemoteGems
+      def self.merge(local_gem_list, remote_gem_list)
+        names = Set.new(local_gem_list.map { |gem| gem[:name] })
+        local_gem_list + remote_gem_list.reject { |gem| names.include? gem[:name] }
+      end
     end
 
+    module CombineLocalAndRemoteGemVersions
+      IGNORE_DEPENDENCIES = 0..-2
+
+      def self.merge(local_gem_list, remote_gem_list)
+        merged = local_gem_list + remote_gem_list
+        merged.uniq! {|val| val.values[IGNORE_DEPENDENCIES] }
+        merged.sort_by! {|x| x.values[IGNORE_DEPENDENCIES] }
+        merged
+      end
+    end
   end
 end

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -312,7 +312,7 @@ HTML
     end
 
     def combined_gem_list
-      GemListMerge.from(local_gem_list, remote_gem_list)
+      GemListMerge.merge(local_gem_list, remote_gem_list, strategy: Geminabox.rubygems_proxy_merge_strategy)
     end
 
     helpers do

--- a/test/units/geminabox/gem_list_merge_test.rb
+++ b/test/units/geminabox/gem_list_merge_test.rb
@@ -7,28 +7,28 @@ module Geminabox
       list_one = gem_list [:a], [:b]
       list_two = gem_list [:a], [:c]
       expected = gem_list [:a], [:b], [:c]
-      assert_equal expected, GemListMerge.from(list_one, list_two)
+      assert_equal expected, GemListMerge.merge(list_one, list_two, strategy: :combine_local_and_remote_gem_versions)
     end
 
     def test_merge_with_different_versions
       list_one = gem_list [:a], [:b]
       list_two = gem_list [:a, '0.0.2'], [:c]
       expected = gem_list [:a], [:a, '0.0.2'], [:b], [:c]
-      assert_equal expected, GemListMerge.from(list_one, list_two)
+      assert_equal expected, GemListMerge.merge(list_one, list_two, strategy: :combine_local_and_remote_gem_versions)
     end
 
     def test_merge_with_different_versions_and_duplicates
       list_one = gem_list [:a], [:b]
       list_two = gem_list [:a], [:a, '0.0.2'], [:c]
       expected = gem_list [:a], [:a, '0.0.2'], [:b], [:c]
-      assert_equal expected, GemListMerge.from(list_one, list_two)
+      assert_equal expected, GemListMerge.merge(list_one, list_two, strategy: :combine_local_and_remote_gem_versions)
     end
 
     def test_merge_sorts
       list_one = gem_list [:b], [:a]
       list_two = gem_list [:c], [:a], [:a, '0.0.2']
       expected = gem_list [:a], [:a, '0.0.2'], [:b], [:c]
-      assert_equal expected, GemListMerge.from(list_one, list_two)
+      assert_equal expected, GemListMerge.merge(list_one, list_two, strategy: :combine_local_and_remote_gem_versions)
     end
 
     def test_merge_ignores_dependencies
@@ -36,14 +36,21 @@ module Geminabox
       list_two = gem_list [:a]
       list_two.first[:dependencies] = [{foo: :bar}]
       expected = gem_list [:a]
-      assert_equal expected, GemListMerge.from(list_one, list_two)
+      assert_equal expected, GemListMerge.merge(list_one, list_two, strategy: :combine_local_and_remote_gem_versions)
     end
 
     def test_merge_with_empty_list
       list_one = gem_list [:a], [:b]
       list_two = []
       expected = gem_list [:a], [:b]
-      assert_equal expected, GemListMerge.from(list_one, list_two)
+      assert_equal expected, GemListMerge.merge(list_one, list_two, strategy: :combine_local_and_remote_gem_versions)
+    end
+
+    def test_local_gems_take_precedence_over_remote_gems_merge_strategy
+      list_one = gem_list [:b], [:a]
+      list_two = gem_list [:c], [:a], [:a, '0.0.2']
+      expected = gem_list [:b], [:a], [:c]
+      assert_equal expected, GemListMerge.merge(list_one, list_two, strategy: :local_gems_take_precedence_over_remote_gems)
     end
 
     def build_gem(name, number = '0.0.1')
@@ -57,14 +64,6 @@ module Geminabox
 
     def gem_list(*conf)
       conf.map{|args| build_gem(*args)}
-    end
-
-    def gem_list_merge
-      @gem_list_merge ||= GemListMerge.new(x_y_list)
-    end
-
-    def x_y_list
-      @x_y_list ||= gem_list([:x], [:y])
     end
 
   end


### PR DESCRIPTION
Rather than combine all gems from BOTH repositories, only include
upstream gems if a gem with the same name is NOT PRESENT LOCALLY.

This is a breaking behavior change in the interest of shipping Geminabox
in a "secure by default" configuration.

To restore the previous behavior, exposing yourself to this vuln:
* Set env var: `RUBYGEMS_PROXY_MERGE_STRATEGY=combine_local_and_remote_gem_versions`
* Add to config.ru: `Geminabox.rubygems_proxy_merge_strategy = :combine_local_and_remote_gem_versions`

One reason to keep the old behavior is if you use Geminabox to override
a public gem version with your own private gem build. In this case,
recommend using Bundler to pin to a private gem source or releasing a
forked gem with a different version instead.

https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610