### PR TITLE
Fixed. doesn't work on Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-bundler_args: --without development
+bundler_args: --without development --path vendor/bundle
 rvm:
   - 2.2.10
   - 2.3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
   - 2.4.6
   - 2.5.4
   - 2.6.2
+  - 2.7.2
+  - 3.0.0
 
 before_install:
   - gem update --system $gemver

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,13 @@ before_install:
 
 env:
   - gemver: 2.7.9
+  - gemver: 3.2.3
+
+jobs:
+  exclude:
+    # rubygems-update v3.0.0+ requires ruby 2.3.0+
+    - rvm: 2.2.10
+      env: gemver=3.2.3
+
+    - rvm: 3.0.0
+      env: gemver=2.7.9

--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,13 @@ group :test do
   gem 'rack-test'
   gem 'minitest'
 
-  # FIXME: test is failed on Ruby 3.0+
-  # c.f. https://github.com/jeroenvandijk/capybara-mechanize/issues/68
-  gem 'capybara-mechanize', github: 'tomstuart/capybara-mechanize', ref: '64073e9'
+  if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create("3.0.0")
+    # FIXME: test is failed on Ruby 3.0+
+    # c.f. https://github.com/jeroenvandijk/capybara-mechanize/issues/68
+    gem 'capybara-mechanize', github: 'tomstuart/capybara-mechanize', ref: '64073e9'
+  else
+    gem 'capybara-mechanize', '1.10.0'
+  end
 
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,10 @@ group :test do
   gem 'rake'
   gem 'rack-test'
   gem 'minitest'
-  gem 'capybara-mechanize'
+
+  # FIXME: test is failed on Ruby 3.0+
+  # c.f. https://github.com/jeroenvandijk/capybara-mechanize/issues/68
+  gem 'capybara-mechanize', github: 'tomstuart/capybara-mechanize', ref: '64073e9'
+
   gem 'webmock'
 end

--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency('nesty')
   s.add_dependency('faraday')
   s.add_dependency('reentrant_flock')
+  s.add_dependency('rss')
 end

--- a/test/test_support/geminabox_test_case.rb
+++ b/test/test_support/geminabox_test_case.rb
@@ -120,7 +120,16 @@ class Geminabox::TestCase < Minitest::Test
   end
 
   def without_bundler
-    defined?(Bundler) ? Bundler.with_clean_env { yield } : yield
+    if defined?(Bundler)
+      if Bundler.respond_to?(:with_unbundled_env)
+        Bundler.with_unbundled_env { yield }
+      else
+        # NOTE: Bundler.with_clean_env is deprecated since bundler v2
+        Bundler.with_clean_env { yield }
+      end
+    else
+      yield
+    end
   end
 
   def execute(command)


### PR DESCRIPTION
`rss` gem is moved to bundled gem since ruby 3.0.0.

c.f. https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

So I added `rss` to runtime dependency

# Example
```ruby
# geminabox_patch.rb
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "geminabox", "1.2.0"
end

require "geminabox"
```

```
$ ruby -v
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin17]

$ ruby geminabox_patch.rb
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Using bundler 2.2.3
Using faraday-net_http 1.0.1
Using httpclient 2.8.3
Using builder 3.2.4
Using ruby2_keywords 0.0.4
Using multipart-post 2.1.1
Using nesty 1.0.2
Using reentrant_flock 0.1.1
Using rack 2.2.3
Using tilt 2.0.10
Using mustermann 1.1.1
Using rack-protection 2.1.0
Using faraday 1.3.0
Using sinatra 2.1.0
Using geminabox 1.2.0
/Users/sue445/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/geminabox-1.2.0/lib/geminabox.rb:8:in `require': cannot load such file -- rss/atom (LoadError)
	from /Users/sue445/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/geminabox-1.2.0/lib/geminabox.rb:8:in `<top (required)>'
	from /Users/sue445/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/runtime.rb:66:in `require'
	from /Users/sue445/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/runtime.rb:66:in `block (2 levels) in require'
	from /Users/sue445/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/runtime.rb:61:in `each'
	from /Users/sue445/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/runtime.rb:61:in `block in require'
	from /Users/sue445/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/runtime.rb:50:in `each'
	from /Users/sue445/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/runtime.rb:50:in `require'
	from /Users/sue445/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/inline.rb:70:in `block in gemfile'
	from /Users/sue445/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/settings.rb:115:in `temporary'
	from /Users/sue445/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/inline.rb:54:in `gemfile'
	from geminabox_patch.rb:3:in `<main>'
```

# Other fixes
* Add ruby 2.7 and 3.0 to CI matrix
* Fix test for ruby 3.0
* Resolved deprecation warning for ruby 3.0