### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 bundler_args: --without development
 rvm:
   - 2.2.10


### PR DESCRIPTION
Would be interested to know why bundler cache hasn't been enabled on Travis. Thank you.