### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.0 (2021-03-18)
+
+Enhancements:
+
+* Prevent "dependency confusion" resulting in a malicious upstream gem taking precedence over a local gem
+
 # 1.2.0 (2020-03-05)
 
 Enhancements:

--- a/lib/geminabox/version.rb
+++ b/lib/geminabox/version.rb
@@ -1,3 +1,3 @@
 module Geminabox
-  VERSION = '1.2.0' unless defined? VERSION
+  VERSION = '1.3.0' unless defined? VERSION
 end


### PR DESCRIPTION
Prevent "dependency confusion" resulting in a malicious upstream gem taking precedence over a local gem