### PR TITLE
Use environmental TMPDIR for lockfile, and add 'rss' as dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_install:
   - gem --version
 
 env:
-  - gemver=2.7.9 TMPDIR=/tmp
+  - gemver: 2.7.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_install:
   - gem --version
 
 env:
-  - gemver=2.7.9 TMDIR=/tmp
+  - gemver=2.7.9 TMPDIR=/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,4 @@ before_install:
   - gem --version
 
 env:
-  - gemver: 2.7.9
-  - TMDIR: '/tmp'
+  - gemver=2.7.9 TMDIR=/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ before_install:
 
 env:
   - gemver: 2.7.9
+  - TMDIR: '/tmp'

--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency('nesty')
   s.add_dependency('faraday')
   s.add_dependency('reentrant_flock')
+  s.add_dependency('rss')
 end

--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -67,7 +67,7 @@ module Geminabox
     def settings
       Server.settings
     end
-    
+
     def call(env)
       Server.call env
     end
@@ -85,7 +85,7 @@ module Geminabox
     rubygems_proxy_merge_strategy:  ENV.fetch('RUBYGEMS_PROXY_MERGE_STRATEGY') { :local_gems_take_precedence_over_remote_gems }.to_sym,
     allow_delete:                   true,
     http_adapter:                   HttpClientAdapter.new,
-    lockfile:                       '/tmp/geminabox.lockfile',
+    lockfile:                       File.join(ENV['TMPDIR'], 'geminabox.lockfile'),
     retry_interval:                 60,
     allow_remote_failure:           false,
     ruby_gems_url:                  'https://rubygems.org/',
@@ -93,5 +93,5 @@ module Geminabox
     allow_upload:                   true,
     on_gem_received:                nil
   )
-    
+
 end

--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -85,7 +85,7 @@ module Geminabox
     rubygems_proxy_merge_strategy:  ENV.fetch('RUBYGEMS_PROXY_MERGE_STRATEGY') { :local_gems_take_precedence_over_remote_gems }.to_sym,
     allow_delete:                   true,
     http_adapter:                   HttpClientAdapter.new,
-    lockfile:                       File.join(ENV['TMPDIR'], 'geminabox.lockfile'),
+    lockfile:                       File.join(ENV.fetch('TMPDIR', '/tmp'), 'geminabox.lockfile'),
     retry_interval:                 60,
     allow_remote_failure:           false,
     ruby_gems_url:                  'https://rubygems.org/',


### PR DESCRIPTION
Basic premise here is that some systems (including the one I'm using) don't allow writes to `/tmp`.  And any standard system should be using the `TMPDIR` env var to identify where you can actually write to tmp, however this still falls back to `/tmp` in the cases where the var simply doesn't exist, which should make it a non-breaking change for current users.

Also for whatever reason on all my systems I can't bundle it unless I add the gem `rss`...I'm using Ruby 3.0.