### PR TITLE
Fix rendering of 503 error when lock is still held

### DIFF
--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -206,7 +206,7 @@ module Geminabox
     def serialize_update(&block)
       with_rlock(&block)
     rescue ReentrantFlock::AlreadyLocked
-      halt 503, { 'Retry-After' => Geminabox.retry_interval }, 'Repository lock is held by another process'
+      halt 503, { 'Retry-After' => Geminabox.retry_interval.to_s }, 'Repository lock is held by another process'
     end
 
     def with_rlock(&block)

--- a/test/units/geminabox/server_test.rb
+++ b/test/units/geminabox/server_test.rb
@@ -101,7 +101,7 @@ module Geminabox
         @server.send(:serialize_update){}
         expected_args = [
           503,
-          {'Retry-After' => Geminabox.retry_interval},
+          { 'Retry-After' => Geminabox.retry_interval.to_s },
           'Repository lock is held by another process'
         ]
         assert_equal expected_args, @server.args


### PR DESCRIPTION
Rendering the error message was causing a RackLint error, because the value of HTTP Headers is always supposed to be a string

    Rack::Lint::LintError: a header value must be a String, but the value of 'Retry-After' is a Integer

Now this error case should behave compliant to the rack specification.