### PR TITLE
Remove space around host.

### DIFF
--- a/lib/rubygems/commands/inabox_command.rb
+++ b/lib/rubygems/commands/inabox_command.rb
@@ -74,7 +74,7 @@ class Gem::Commands::InaboxCommand < Gem::Command
   def configure
     say "Enter the root url for your personal geminabox instance (e.g. http://gems/)."
     host = ask("Host:")
-    self.geminabox_host = host
+    self.geminabox_host = host.strip
   end
 
   def geminabox_host


### PR DESCRIPTION
I can insert spaces around host.
It isn't recognized as the correct URL.

```
root@7f083f6b9f96:/app# gem inabox -c
Enter the root url for your personal geminabox instance (e.g. http://gems/).
Host:   https://www.kaeruspoon.net 
root@7f083f6b9f96:/app# cat ~/.gem/geminabox 
---
:host: " https://www.kaeruspoon.net "
root@7f083f6b9f96:/app# gem inabox geminabox-1.4.1.gem 
ERROR:  While executing gem ... (URI::InvalidURIError)
    bad URI(is not URI?): " https://www.kaeruspoon.net "
```

This PullRequest fix it.

```
root@38320f9bc268:/app# gem inabox -c 
Enter the root url for your personal geminabox instance (e.g. http://gems/).
Host:   https://www.kaeruspoon.net 
root@38320f9bc268:/app# cat ~/.gem/geminabox 
---
:host: https://www.kaeruspoon.net
root@38320f9bc268:/app# gem inabox geminabox-1.4.1.gem 
Pushing geminabox-1.4.1.gem to https://www.kaeruspoon.net/...
ERROR:  Error (405 received)

<html>
<head><title>405 Not Allowed</title></head>
<body bgcolor="white">
<center><h1>405 Not Allowed</h1></center>
</body>
</html>
````

