### PR TITLE
Use a binary mode for file manipulations

### DIFF
--- a/lib/geminabox/proxy/copier.rb
+++ b/lib/geminabox/proxy/copier.rb
@@ -24,7 +24,7 @@ module Geminabox
       def get_remote
         begin
           if rc = remote_content
-            File.open(proxy_path, 'w'){|f| f.write(rc) }
+            File.open(proxy_path, 'wb'){|f| f.write(rc) }
           end
         rescue
           File.unlink(proxy_path) if File.exist?(proxy_path)

--- a/lib/geminabox/proxy/file_handler.rb
+++ b/lib/geminabox/proxy/file_handler.rb
@@ -44,7 +44,7 @@ module Geminabox
       end
 
       def remote_content
-        Geminabox.http_adapter.get_content(remote_url).force_encoding(encoding)
+        Geminabox.http_adapter.get_content(remote_url)
       rescue
         return nil if Geminabox.allow_remote_failure
         raise GemStoreError.new(500, "Unable to get content from #{remote_url}")
@@ -55,7 +55,7 @@ module Geminabox
       end
 
       def local_content
-        File.read(local_path).force_encoding(encoding)
+        File.binread(local_path)
       end
 
       private

--- a/lib/geminabox/proxy/splicer.rb
+++ b/lib/geminabox/proxy/splicer.rb
@@ -17,6 +17,7 @@ module Geminabox
       def create
         if data = new_content
           f = Tempfile.create('geminabox')
+          f.binmode
           begin
             f.write(data)
           ensure

--- a/test/units/geminabox/incoming_gem_test.rb
+++ b/test/units/geminabox/incoming_gem_test.rb
@@ -47,10 +47,11 @@ module Geminabox
 
     test "#hexdigest" do
       file_name = GemFactory.gem_file(:example)
-      file = File.open(file_name)
-      subject = Geminabox::IncomingGem.new(file)
+      File.open(file_name) do |file|
+        subject = Geminabox::IncomingGem.new(file)
 
-      assert_equal Digest::SHA1.hexdigest(File.read(file_name)), subject.hexdigest
+        assert_equal Digest::SHA1.hexdigest(File.binread(file_name)), subject.hexdigest
+      end
     end
 
   end

--- a/test/units/geminabox/proxy/splicer_test.rb
+++ b/test/units/geminabox/proxy/splicer_test.rb
@@ -23,7 +23,7 @@ module Geminabox
         test_create
         assert_equal(
           Marshal.load(Gem::Util.gunzip remote_content),
-          Marshal.load(Gem::Util.gunzip File.read(splice.splice_path))
+          Marshal.load(Gem::Util.gunzip File.binread(splice.splice_path))
         )
       end
 
@@ -33,7 +33,7 @@ module Geminabox
         test_create
         assert_equal(
           Marshal.load(Gem::Util.gunzip merged_content),
-          Marshal.load(Gem::Util.gunzip File.read(splice.splice_path))
+          Marshal.load(Gem::Util.gunzip File.binread(splice.splice_path))
         )
       end
 
@@ -41,8 +41,8 @@ module Geminabox
         create_local_content
         test_create
         assert_equal(
-          local_content.force_encoding("UTF-8").to_s + remote_content.force_encoding("UTF-8").to_s,
-          File.read(splice.splice_path)
+          local_content.to_s + remote_content.to_s,
+          File.binread(splice.splice_path)
         )
       end
 
@@ -112,7 +112,7 @@ module Geminabox
       end
 
       def create_local_content
-        File.open(splice.local_path, 'w'){|f| f.write(local_content)}
+        File.open(splice.local_path, 'wb'){|f| f.write(local_content)}
       end
 
       def stub_request_for_file(file_name)


### PR DESCRIPTION
It's a bad idea to depend on text mode for a binary content like gems or gzipped files