### PR TITLE
Do not transform compressed files

### DIFF
--- a/lib/geminabox/hostess.rb
+++ b/lib/geminabox/hostess.rb
@@ -6,6 +6,7 @@ module Geminabox
 
   class Hostess < Sinatra::Base
     def serve
+      headers["Cache-Control"] = 'no-transform'
       send_file(File.expand_path(File.join(Geminabox.data, *request.path_info)), :type => response['Content-Type'])
     end
 

--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -8,6 +8,7 @@ module Geminabox
     class Hostess < Sinatra::Base
       attr_accessor :file_handler
       def serve
+        headers["Cache-Control"] = 'no-transform'
         if file_handler
           send_file file_handler.proxy_path
         else


### PR DESCRIPTION
these requests shouldn't be transformed by a middleware like deflater. It could compress the file twice and corrupt it. This header prevents that.