### PR TITLE
Deprecate using legacy index

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ Create a config.ru as follows:
 
 Start your gem server with 'rackup' to run WEBrick or hook up the config.ru as you normally would ([passenger](https://www.phusionpassenger.com/), [thin](http://code.macournoyer.com/thin/), [unicorn](https://bogomips.org/unicorn/), whatever floats your boat).
 
-## Legacy RubyGems index
-
-RubyGems supports generating indexes for the so called legacy versions (< 1.2), and since it is very rare to use such versions nowadays, it can be disabled, thus improving indexing times for large repositories. If it's safe for your application, you can disable support for these legacy versions by adding the following configuration to your config.ru file:
-
-    Geminabox.build_legacy = false
-
 ## RubyGems Proxy
 
 Geminabox can be configured to pull gems, it does not currently have, from rubygems.org. To enable this mode you can either:

--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -39,7 +39,6 @@ module Geminabox
     attr_accessor(
       :data,
       :public_folder,
-      :build_legacy,
       :incremental_updates,
       :views,
       :allow_replace,
@@ -56,6 +55,14 @@ module Geminabox
       :allow_upload,
       :on_gem_received
     )
+
+    attr_reader :build_legacy
+
+    def build_legacy=(value)
+      warn "Setting `Geminabox.build_legacy` is deprecated and will be removed in the future. Geminbox will always build modern indices"
+
+      @build_legacy = value
+    end
 
     def set_defaults(defaults)
       defaults.each do |method, default|


### PR DESCRIPTION
Modern indexes are available in rubygems since rubygems 1.2.0. I think we can deprecate using the old method now?