### PR TITLE
Unpin capybara-mechanize on test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,7 @@ group :test do
   gem 'minitest'
 
   if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create("3.0.0")
-    # FIXME: test is failed on Ruby 3.0+
-    # c.f. https://github.com/jeroenvandijk/capybara-mechanize/issues/68
-    gem 'capybara-mechanize', github: 'tomstuart/capybara-mechanize', ref: '64073e9'
+    gem 'capybara-mechanize'
   else
     gem 'capybara-mechanize', '1.10.0'
   end


### PR DESCRIPTION
capybara-mechanize 1.12.0 was already released as seen at https://rubygems.org/gems/capybara-mechanize/versions/1.12.0

- Closes #371

- Updates #340

- Blocks #360

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>