### PR TITLE
remove File.exists? deprecation warning

### DIFF
--- a/lib/geminabox/proxy/copier.rb
+++ b/lib/geminabox/proxy/copier.rb
@@ -27,7 +27,7 @@ module Geminabox
             File.open(proxy_path, 'w'){|f| f.write(rc) }
           end
         rescue
-          File.unlink(proxy_path) if File.exists?(proxy_path)
+          File.unlink(proxy_path) if File.exist?(proxy_path)
           raise $!
         end
       end

--- a/test/units/geminabox/proxy/copier_test.rb
+++ b/test/units/geminabox/proxy/copier_test.rb
@@ -16,7 +16,7 @@ module Geminabox
             copier.get_remote
           rescue
           end
-          assert(!File.exists?(copier.proxy_path), "Cached file should not exist")
+          assert(!File.exist?(copier.proxy_path), "Cached file should not exist")
         end
       end
 


### PR DESCRIPTION
The replacement File.exist? has been around since at least 2006.