### PR TITLE
eliminate a faraday 1.x deprecation warning

### DIFF
--- a/lib/geminabox/http_adapter/template_faraday_adapter.rb
+++ b/lib/geminabox/http_adapter/template_faraday_adapter.rb
@@ -27,7 +27,7 @@ module Geminabox
         faraday.adapter http_engine
         faraday.proxy(ENV['http_proxy']) if ENV['http_proxy']
       end
-      set_username_and_password connection, username, password
+      set_username_and_password connection, username, password if username
       connection
     end
 

--- a/lib/geminabox/http_adapter/template_faraday_adapter.rb
+++ b/lib/geminabox/http_adapter/template_faraday_adapter.rb
@@ -27,7 +27,7 @@ module Geminabox
         faraday.adapter http_engine
         faraday.proxy(ENV['http_proxy']) if ENV['http_proxy']
       end
-      connection.basic_auth username, password if username
+      connection.request(:basic_auth, username, password) if username
       connection
     end
 

--- a/lib/geminabox/http_adapter/template_faraday_adapter.rb
+++ b/lib/geminabox/http_adapter/template_faraday_adapter.rb
@@ -27,7 +27,7 @@ module Geminabox
         faraday.adapter http_engine
         faraday.proxy(ENV['http_proxy']) if ENV['http_proxy']
       end
-      connection.request(:basic_auth, username, password) if username
+      set_username_and_password connection, username, password
       connection
     end
 
@@ -47,6 +47,16 @@ module Geminabox
         faraday.adapter http_engine
         faraday.proxy(ENV['http_proxy']) if ENV['http_proxy']
       }
+    end
+
+    private
+
+    def set_username_and_password(connection, username, password)
+      if Gem::Version.new(Faraday::VERSION) < Gem::Version.new("1.0")
+        connection.basic_auth username, password
+      else
+        connection.request :basic_auth, username, password
+      end
     end
 
   end


### PR DESCRIPTION
See https://lostisland.github.io/faraday/middleware/authentication.