### PR TITLE
removed confusing backtrace from test output

### DIFF
--- a/test/units/geminabox/proxy/copier_test.rb
+++ b/test/units/geminabox/proxy/copier_test.rb
@@ -10,7 +10,7 @@ module Geminabox
       end
 
       def test_remote_content_failure
-        raise_stub = proc { puts caller.join("\n") ; raise }
+        raise_stub = proc { raise }
         copier.stub :remote_content, raise_stub do
           begin
             copier.get_remote


### PR DESCRIPTION
I always think something is wrong when I see a backtrace in test output. I suggest to remove it, as it does not seem to be necessary. I'm assuming this is a forgotten debug output.