### PR TITLE
Unpin capybara-mechanize gem on CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,10 @@ group :test do
   gem 'rack-test'
   gem 'minitest'
 
-  if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create("3.0.0")
-    gem 'capybara-mechanize'
-    gem 'capybara', '~> 3.36.0' # Pin to 3.36.x
-  else
-    gem 'capybara-mechanize', '1.10.0'
-  end
+  gem 'capybara-mechanize'
+  # Pin capybara to 3.36.x or earlier as 3.37.x does not work with Ruby 2.7/3.0/3.1
+  # see https://github.com/teamcapybara/capybara/pull/2546
+  gem 'capybara', '< 3.37.0'
 
   # Pin multipart-post 2.1.x on Ruby 2.2 or earlier.
   # You can remove this block when multipart-post 2.2.0 is yanked


### PR DESCRIPTION
Unpin capybara-mechanize gem on CI by tentatively pinning capybara to 3.36.0 or earlier as capybara 3.37.0 has a breaking change to us: https://github.com/teamcapybara/capybara/pull/2546

Replaces #389

Follows up https://github.com/geminabox/geminabox/pull/360/commits/6a7a17b0fc1c79cd52a90b5fb36d8241f991d7f5 and #340

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)