### PR TITLE
Drop RubyGems 1.8.24 and earlier

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,16 +23,22 @@ jobs:
             gem-version: 2.7.11
           - ruby-version: 2.5.9
             gem-version: 2.7.11
+          # RubyGems 1.8 should be tested
           - ruby-version: 2.2.10
             gem-version: 1.8.25
+            continue-on-error: true
           - ruby-version: 2.3.8
             gem-version: 1.8.25
+            continue-on-error: true
           - ruby-version: 2.4.10
             gem-version: 1.8.25
+            continue-on-error: true
           - ruby-version: 2.5.9
             gem-version: 1.8.25
+            continue-on-error: true
           - ruby-version: 2.6.10
             gem-version: 1.8.25
+            continue-on-error: true
 
     steps:
     - uses: actions/checkout@v3
@@ -47,10 +53,21 @@ jobs:
       run: |
         gem update --system $gemver
         gem --version
-    - if: startsWith(matrix.gem-version, '1.')
-      run: sed -i -e "/metadata/d" geminabox.gemspec
+    # TODO: remove this step when RubyGems 1.8 support is dropped
+    # RubyGems 1.8 does not support Gem::Specification#metadata=, so removing the line
+    # https://github.com/rubygems/rubygems/commit/be483b99d8a53bce3e6faf9e6f3c3a5df452974e
+    # or https://github.com/rubygems/rubygems/pull/38
+    # Use Bundler 1.17 when using RubyGems 1.8
+    - name: Tweak gemspec fixtures for testing and use Bundler 1.x
+      if: startsWith(matrix.gem-version, '1.')
+      run: |
+        sed -i -e "/metadata/d" geminabox.gemspec
+        gem uninstall bundler
+        gem install bundler --version "< 2"
+        sed -i -e "/^BUNDLED WITH/ {n; s/.*/  1.17.3/} " Gemfile.lock
     - name: Run tests
       run: bundle exec rake
+      continue-on-error: ${{ matrix.continue-on-error }}
 
   rubocop:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,6 +23,16 @@ jobs:
             gem-version: 2.7.11
           - ruby-version: 2.5.9
             gem-version: 2.7.11
+          - ruby-version: 2.2.10
+            gem-version: 1.8.25
+          - ruby-version: 2.3.8
+            gem-version: 1.8.25
+          - ruby-version: 2.4.10
+            gem-version: 1.8.25
+          - ruby-version: 2.5.9
+            gem-version: 1.8.25
+          - ruby-version: 2.6.10
+            gem-version: 1.8.25
 
     steps:
     - uses: actions/checkout@v3
@@ -37,6 +47,8 @@ jobs:
       run: |
         gem update --system $gemver
         gem --version
+    - if: startsWith(matrix.gem-version, '1.')
+      run: sed -i -e "/metadata/d" geminabox.gemspec
     - name: Run tests
       run: bundle exec rake
 

--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -10,7 +10,8 @@ Gem::Specification.new do |s|
   s.homepage          = 'http://tomlea.co.uk/p/gem-in-a-box'
   s.metadata          = { "source_code_uri" => "https://github.com/geminabox/geminabox" }
 
-  s.required_ruby_version =  ">= 2.2.0"
+  s.required_ruby_version     = ">= 2.2.0"
+  s.required_rubygems_version = ">= 1.8.25"
 
   s.extra_rdoc_files  = %w[README.md]
   s.rdoc_options      = %w[--main README.md]


### PR DESCRIPTION
Part of #422

Also adds testing with RubyGems 1.8.25, which are failing at this moment.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>