### PR TITLE
Drop support RubyGems 2.3.x and earlier

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,21 +23,24 @@ jobs:
             gem-version: 2.7.11
           - ruby-version: 2.5.9
             gem-version: 2.7.11
-          # RubyGems 1.8 should be tested
+          # Test with RubyGems 2.4.8 as it is specified in gemspec
           - ruby-version: 2.2.10
-            gem-version: 1.8.25
+            gem-version: 2.4.8
             continue-on-error: true
           - ruby-version: 2.3.8
-            gem-version: 1.8.25
+            gem-version: 2.4.8
             continue-on-error: true
           - ruby-version: 2.4.10
-            gem-version: 1.8.25
+            gem-version: 2.4.8
             continue-on-error: true
           - ruby-version: 2.5.9
-            gem-version: 1.8.25
+            gem-version: 2.4.8
             continue-on-error: true
           - ruby-version: 2.6.10
-            gem-version: 1.8.25
+            gem-version: 2.4.8
+            continue-on-error: true
+          - ruby-version: 2.7.6
+            gem-version: 2.4.8
             continue-on-error: true
 
     steps:
@@ -53,15 +56,11 @@ jobs:
       run: |
         gem update --system $gemver
         gem --version
-    # TODO: remove this step when RubyGems 1.8 support is dropped
-    # RubyGems 1.8 does not support Gem::Specification#metadata=, so removing the line
-    # https://github.com/rubygems/rubygems/commit/be483b99d8a53bce3e6faf9e6f3c3a5df452974e
-    # or https://github.com/rubygems/rubygems/pull/38
-    # Use Bundler 1.17 when using RubyGems 1.8
-    - name: Tweak gemspec fixtures for testing and use Bundler 1.x
-      if: startsWith(matrix.gem-version, '1.')
+    # TODO: remove this step when RubyGems 2.4 support is dropped
+    # Use Bundler 1.17 when using RubyGems 1.x and 2.0-2.4
+    - name: Install Bundler 1.x for RubyGems 2.4
+      if: startsWith(matrix.gem-version, '2.4')
       run: |
-        sed -i -e "/metadata/d" geminabox.gemspec
         gem uninstall bundler
         gem install bundler --version "< 2"
         sed -i -e "/^BUNDLED WITH/ {n; s/.*/  1.17.3/} " Gemfile.lock

--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.metadata          = { "source_code_uri" => "https://github.com/geminabox/geminabox" }
 
   s.required_ruby_version     = ">= 2.2.0"
-  s.required_rubygems_version = ">= 1.8.25"
+  s.required_rubygems_version = ">= 2.4.0"
 
   s.extra_rdoc_files  = %w[README.md]
   s.rdoc_options      = %w[--main README.md]


### PR DESCRIPTION
Set `required_rubygems_version` to `=> 2.4.0` in gemspec. RubyGems 2.4.x is the default gem of Ruby 2.2.x (the oldest supported Ruby version) (see https://stdgems.org/2.2.0/).

As RubyGems 2.4.x, 2.5.0, and 2.5.1 does not support `gem yank --host` (https://github.com/rubygems/rubygems/pull/1361), tests added in this PR are with RubyGems 2.5.2.

Tests using `gem yank` CLI are always failing with RubyGems 2.4.x as follows:

```
$ bundle exec rake

[...]

Finished in 25.657103s, 1.0523 runs/s, 3.7417 assertions/s.
  1) Failure:
GemcutterApiYankTest#test_method: can yank example  [/home/runner/work/geminabox/geminabox/test/test_support/geminabox_test_case.rb:76]:
Gemfile in data dir.
27 runs, 96 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1)
```

https://github.com/geminabox/geminabox/runs/7083936756?check_suite_focus=true

Closes #427 and #424

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>