### PR TITLE
Remove patch for RubyGems 1.8.24 or earlier

### DIFF
--- a/lib/geminabox/indexer.rb
+++ b/lib/geminabox/indexer.rb
@@ -1,26 +1,9 @@
 # frozen_string_literal: true
 
-# This module addresses Geminabox issue
-# https://github.com/cwninja/geminabox/issues/70
-#
-# The underlying problem is rubygems issue
-# https://github.com/rubygems/rubygems/issues/232, fixed by
-# https://github.com/rubygems/rubygems/pull/364
-#
-# This library (and its call) should be deleted once that pull request is resolved.
-
 require 'geminabox'
 require 'rubygems/indexer'
 
 module Geminabox::Indexer
-  def self.germane?
-    gem_version = Gem::Version.new(Gem::VERSION)
-    v1_8        = Gem::Version.new('1.8')
-    v1_8_25     = Gem::Version.new('1.8.25')
-
-    (gem_version >= v1_8) && (gem_version < v1_8_25)
-  end
-
   def self.updated_gemspecs(indexer)
     specs_mtime = File.stat(indexer.dest_specs_index).mtime rescue Time.at(0)
     newest_mtime = Time.at 0
@@ -32,16 +15,5 @@ module Geminabox::Indexer
     end
 
     indexer.map_gems_to_specs updated_gems
-  end
-
-  def self.patch_rubygems_update_index_pre_1_8_25(indexer)
-    if germane?
-      specs = updated_gemspecs(indexer)
-
-      unless specs.empty?
-        Gem::Specification.dirs = []
-        Gem::Specification.add_specs(*specs)
-      end
-    end
   end
 end

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -46,7 +46,6 @@ module Geminabox
             require 'geminabox/indexer'
             updated_gemspecs = Geminabox::Indexer.updated_gemspecs(indexer)
             return if updated_gemspecs.empty?
-            Geminabox::Indexer.patch_rubygems_update_index_pre_1_8_25(indexer)
             indexer.update_index
             updated_gemspecs.each { |gem| dependency_cache.flush_key(gem.name) }
           rescue Errno::ENOENT


### PR DESCRIPTION
As support for RubyGems 1.8.24 and earlier was dropped in #423, we can safely remove the patch for these versions.

Reverts most of #80 

Closes #422

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>