### PR TITLE
Move to normal for actions/stale only for PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,8 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 365
+        days-before-pr-stale: 60
+        days-before-issue-stale: 365
         days-before-close: 14
         stale-issue-message: 'Could you update this issue?'
         stale-pr-message: 'You should update this pull request by commenting on it. Otherwise the PR will be closed in 14 days.'


### PR DESCRIPTION
All stale PRs has been tackled for a week, now we can use shorter period to make mentions to contributors.

Updates #407

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>