### PR TITLE
Remove IncomingGem code for RubyGems 1.x

### DIFF
--- a/lib/geminabox/incoming_gem.rb
+++ b/lib/geminabox/incoming_gem.rb
@@ -33,17 +33,7 @@ module Geminabox
     end
 
     def spec
-      @spec ||= extract_spec
-    end
-
-    def extract_spec
-      if Gem::Package.respond_to? :open
-        Gem::Package.open(gem_data, "r", nil) do |pkg|
-          return pkg.metadata
-        end
-      else
-        Gem::Package.new(@tempfile.path).spec
-      end
+      @spec ||= Gem::Package.new(@tempfile.path).spec
     end
 
     def name


### PR DESCRIPTION
`Gem::Package.open` was removed in RubyGems 2.0.0 at https://github.com/rubygems/rubygems/commit/090c39bd5e4a28e51d6ef8de9efa58ed597cc91c

- Original code: 7518da10
- Blocked by #428

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)