### PR TITLE
Update RuboCop from 1.30.1 to 1.31.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -78,7 +78,7 @@ jobs:
         ruby-version: 3.1.2
     - name: Run RuboCop
       run: |
-        bundle add rubocop --version 1.30.1
+        bundle add rubocop --version 1.31.0
         bundle add rubocop-minitest --version 0.20.1
         bundle add rubocop-rake --version 0.6.0
         bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,12 @@ AllCops:
   NewCops: enable
   SuggestExtensions: false
 
+# Disabling this cop at this moment
+# https://github.com/rubocop/rubocop/pull/10696
+Lint/NonAtomicFileOperation:
+  Enabled: false
+
+# The following is a workaround for disorder in rubocop auto-gen-config
 Layout/SpaceBeforeBlockBraces:
   Exclude:
     - 'lib/geminabox_client.rb'
@@ -22,3 +28,4 @@ Layout/SpaceBeforeBlockBraces:
 Naming/MethodName:
   Exclude:
     - 'test/units/geminabox/server_test.rb'
+# DO NOT ADD BELOW THIS SECTION

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -188,13 +188,6 @@ Layout/EmptyLinesAroundModuleBody:
     - 'test/units/geminabox/disk_cache_test.rb'
     - 'test/units/geminabox/rubygems_dependency_test.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowForAlignment, AllowBeforeTrailingComments, ForceEqualSignAlignment.
-Layout/ExtraSpacing:
-  Exclude:
-    - 'geminabox.gemspec'
-
 # Offense count: 6
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: IndentationWidth.
@@ -514,14 +507,6 @@ Naming/RescuedExceptionsVariableName:
     - 'test/units/geminabox/gem_store_error_test.rb'
     - 'test/units/geminabox/gem_store_test.rb'
 
-# Offense count: 3
-# Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers, AllowedPatterns.
-# SupportedStyles: snake_case, normalcase, non_integer
-# AllowedIdentifiers: capture3, iso8601, rfc1123_date, rfc822, rfc2822, rfc3339
-Naming/VariableNumber:
-  Exclude:
-    - 'lib/geminabox/indexer.rb'
-
 # Offense count: 1
 Security/Eval:
   Exclude:
@@ -589,14 +574,6 @@ Style/ColonMethodCall:
     - 'lib/geminabox/server.rb'
     - 'lib/geminabox_client.rb'
     - 'test/test_support/geminabox_test_case.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, SingleLineConditionsOnly, IncludeTernaryExpressions.
-# SupportedStyles: assign_to_condition, assign_inside_condition
-Style/ConditionalAssignment:
-  Exclude:
-    - 'lib/geminabox/incoming_gem.rb'
 
 # Offense count: 26
 # Configuration parameters: AllowedConstants.


### PR DESCRIPTION
`Lint/NonAtomicFileOperation` cop (https://github.com/rubocop/rubocop/pull/10696) is disabled at this moment.

Some TODOs were already resolved in #423 and #429 and are removed.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)