### PR TITLE
Limit sinatra dependency to 2.x by dropping 1.x

### DIFF
--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.files             = %w[MIT-LICENSE README.md] + Dir['{lib,public,views}/**/*']
   s.require_paths     = ['lib']
 
-  s.add_dependency('sinatra', [">= 1.2.7"])
+  s.add_dependency('sinatra', "~> 2.0")
   s.add_dependency('builder')
   s.add_dependency('httpclient', [">= 2.2.7"])
   s.add_dependency('nesty')


### PR DESCRIPTION
Limits sinatra dependency to 2.x to disallows 3.x by dropping 1.x.

This helps admins to use Rack 2.x. Rack 2.0, 2.1, and 2.2 are still properly maintained as of this summer.

https://discuss.rubyonrails.org/t/cve-2022-30122-denial-of-service-vulnerability-in-rack-multipart-parsing/80729

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)