### PR TITLE
Allow admins to use Faraday v2 with Ruby 2.6+

### DIFF
--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('builder')
   s.add_dependency('httpclient', [">= 2.2.7"])
   s.add_dependency('nesty')
-  s.add_dependency('faraday', "< 2.0")
+  s.add_dependency('faraday', "< 3.0")
   s.add_dependency('reentrant_flock')
   s.add_dependency('rss')
 end

--- a/lib/geminabox/http_adapter/template_faraday_adapter.rb
+++ b/lib/geminabox/http_adapter/template_faraday_adapter.rb
@@ -39,7 +39,7 @@ module Geminabox
     end
 
     def http_engine
-      :net_http  # make requests with Net::HTTP
+      :net_http # make requests with Net::HTTP
     end
 
     def options
@@ -52,10 +52,15 @@ module Geminabox
     private
 
     def set_username_and_password(connection, username, password)
+      # Remove this condition when Faraday 0.x dropped (when Ruby 2.2 dropped)
       if Gem::Version.new(Faraday::VERSION) < Gem::Version.new("1.0")
         connection.basic_auth username, password
-      else
+      # Remove this condition when Faraday 1.x dropped (when Ruby 2.5 dropped)
+      elsif Gem::Version.new(Faraday::VERSION) < Gem::Version.new("2.0")
         connection.request :basic_auth, username, password
+      else
+        # Faraday 2.x
+        connection.request :authorization, :basic, username, password
       end
     end
 


### PR DESCRIPTION
This is now allowed by #385.

- Closes #375
- Updates #360 (which was in a stupid way 🙏 )

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>