### PR TITLE
Drop Faraday v0 support

### DIFF
--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency('builder')
   s.add_dependency('httpclient', [">= 2.2.7"])
   s.add_dependency('nesty')
-  s.add_dependency('faraday', "< 3.0")
+  s.add_dependency('faraday', "> 1.0", "< 3.0")
   s.add_dependency('reentrant_flock')
 end

--- a/lib/geminabox/http_adapter/template_faraday_adapter.rb
+++ b/lib/geminabox/http_adapter/template_faraday_adapter.rb
@@ -52,11 +52,8 @@ module Geminabox
     private
 
     def set_username_and_password(connection, username, password)
-      # Remove this condition when Faraday 0.x dropped (when Ruby 2.2 dropped)
-      if Gem::Version.new(Faraday::VERSION) < Gem::Version.new("1.0")
-        connection.basic_auth username, password
       # Remove this condition when Faraday 1.x dropped (when Ruby 2.5 dropped)
-      elsif Gem::Version.new(Faraday::VERSION) < Gem::Version.new("2.0")
+      if Gem::Version.new(Faraday::VERSION) < Gem::Version.new("2.0")
         connection.request :basic_auth, username, password
       else
         # Faraday 2.x


### PR DESCRIPTION
Use Faraday v2 if you use Ruby 2.6 or higher or v1 if you use Ruby 2.5 or earlier.

We dropped Ruby 2.2 support #449 (#454) and so we do not have to allow admins to use Faraday v0. With a removal of Faraday v0 support, a workaround from #385 can be removed.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)