### PR TITLE
Remove deprecated arguments for rake console

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,6 +47,6 @@ task :default => :test
 
 desc 'Open an irb session preloaded with the gem library'
 task :console do
-  sh 'irb -rubygems -I lib -r geminabox.rb'
+  sh 'irb -I lib -r geminabox.rb'
 end
 task :c => :console


### PR DESCRIPTION
Ruby 2.3 has `rubygems` gem as the default gem and it is automatically loaded without `require` or `-r` option.

On Ruby 2.5.0 or higher, a user will not see warning any more.

- https://github.com/ruby/ruby/blob/v2_5_0/NEWS#stdlib-compatibility-issues-excluding-feature-bug-fixes-

Closes #465

I do not think we really need this...

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)