### PR TITLE
Test all with Ruby 3.2.0 and RubyGems 3.4.1

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Ruby 3.1
       uses: ruby/setup-ruby@v1.128.0
       with:
-        ruby-version: 3.1.2
+        ruby-version: 3.2.0
 
     - name: Publish a pre package to GitHub Packages
       run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.3.8, 2.4.10, 2.5.9, 2.6.10, 2.7.6, 3.0.4, 3.1.2]
-        gem-version: [3.3.15]
+        ruby-version: [2.3.8, 2.4.10, 2.5.9, 2.6.10, 2.7.7, 3.0.5, 3.1.3, 3.2.0]
+        gem-version: [3.3.26]
         include:
           - ruby-version: 2.3.8
             gem-version: 2.7.11
@@ -37,6 +37,17 @@ jobs:
           - ruby-version: 2.7.6
             gem-version: 2.5.0
             continue-on-error: true
+          # Test with RubyGems 3.4.1
+          - ruby-version: 2.6.10
+            gem-version: 3.4.1
+          - ruby-version: 2.7.7
+            gem-version: 3.4.1
+          - ruby-version: 3.0.5
+            gem-version: 3.4.1
+          - ruby-version: 3.1.3
+            gem-version: 3.4.1
+          - ruby-version: 3.2.0
+            gem-version: 3.4.1
 
     steps:
     - uses: actions/checkout@v3
@@ -57,12 +68,12 @@ jobs:
       run: bundle exec rake
       continue-on-error: ${{ matrix.continue-on-error }}
     - name: Workaround for coverage report to CodeClimate with jq
-      if: startsWith(matrix.ruby-version, '3.1')
+      if: startsWith(matrix.ruby-version, '3.2')
       run: |
         jq 'map_values(. | map_values(if type=="object" then map_values(.lines) else . end))' coverage/.resultset.json > coverage/.resultset_workaround.json
         diff -uw coverage/.resultset.json coverage/.resultset_workaround.json || true
     - name: Send coverage report to CodeClimate
-      if: startsWith(matrix.ruby-version, '3.1')
+      if: startsWith(matrix.ruby-version, '3.2')
       continue-on-error: true
       uses: paambaati/codeclimate-action@v3.2.0
       with:
@@ -77,7 +88,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1.128.0
       with:
-        ruby-version: 3.1.2
+        ruby-version: 3.2.0
     - name: Run RuboCop
       run: |
         bundle add rubocop --version 1.31.0


### PR DESCRIPTION
- Closes #510
- Updates RubyGems 3.3 from 3.3.15 to 3.3.26 (latest revision of 3.3.x) on test
- Updates all Ruby revisions from 2.7 through 3.1 on test
- Adds Ruby 3.2 to the test matrix

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)