### PR TITLE
Fix Geminabox::VERSION instantiation failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,20 +186,31 @@ gem 'geminabox'
 
 From there
 
-```
+```sh
 docker build -t geminabox .
 ```
 
-```
-docker run -d -p 9292:9292 geminabox:latest
+```sh
+docker run --name geminabox --rm -d -p 9292:9292 geminabox:latest
 ```
 
 Your server should now be running!
 
+To stop the server
+
+```sh
+docker stop geminabox
+```
 
 ## Running the tests
 
 Running `rake` will run the complete test suite.
+
+Using the docker image built above, one may also run rake in a docker container
+
+```sh
+docker run --rm --volume $PWD/lib:/usr/src/app/lib --volume $PWD/test:/usr/src/app/test --entrypoint rake geminabox:latest
+```
 
 The test suite uses
 [minitest-reporters](https://github.com/minitest-reporters/minitest-reporters)

--- a/lib/geminabox/version.rb
+++ b/lib/geminabox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Geminabox
-  VERSION = '2.2.0.pre' unless defined? VERSION
+  VERSION = '2.2.0.pre' unless defined? Geminabox::VERSION
 end

--- a/test/units/geminabox/server_test.rb
+++ b/test/units/geminabox/server_test.rb
@@ -43,6 +43,12 @@ module Geminabox
       end
     end
 
+    describe 'Geminabox::VERSION' do
+      def test_version
+        assert_equal 'constant', (defined?(Geminabox::VERSION))
+      end
+    end
+
     describe "#with_rlock" do
       include PrepServer
 


### PR DESCRIPTION
See: https://github.com/geminabox/geminabox/issues/506

Getting the following error when using `bundler` to install and run `geminabox`.

```ruby
NameError - uninitialized constant Geminabox::VERSION
```

Problem is that even though the `version.rb` module is being required and loaded successfully, some constant `VERSION` is already defined, and so the `Geminabox` module never gets to define its version because `unless defined? VERSION` evaluates to `false`.