### PR TITLE
use streaming instead of direct gem serve

### DIFF
--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.require_paths     = ['lib']
 
   s.add_dependency('sinatra', "~> 2.0")
+  s.add_dependency('sinatra-contrib')
   s.add_dependency('builder')
   s.add_dependency('httpclient', [">= 2.2.7"])
   s.add_dependency('nesty')

--- a/lib/geminabox/hostess.rb
+++ b/lib/geminabox/hostess.rb
@@ -12,7 +12,7 @@ module Geminabox
       f = File.open(file, "r")
 
       stream do |out|
-        out <<  f.read(1024*1024) until f.eof?
+        out <<  f.read(1024 * 1024) until f.eof?
       end
     end
 

--- a/lib/geminabox/hostess.rb
+++ b/lib/geminabox/hostess.rb
@@ -9,12 +9,10 @@ module Geminabox
     helpers Sinatra::Streaming
 
     def stream_file(file)
-      f = File.open(File.expand_path(File.join(Geminabox.data, *request.path_info)), "r")
+      f = File.open(file, "r")
 
       stream do |out|
-        until f.eof?
-          out <<  f.read( 1024 * 1024 )
-        end
+        out <<  f.read(1024*1024) until f.eof?
       end
     end
 
@@ -22,7 +20,7 @@ module Geminabox
       cache_control "no-transform"
       content_type "application/octet-stream"
 
-      stream_file file
+      stream_file File.expand_path(File.join(Geminabox.data, *request.path_info))
     end
 
     %w[/specs.4.8.gz

--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -13,7 +13,7 @@ module Geminabox
         f = File.open(file, "r")
 
         stream do |out|
-          out <<  f.read(1024*1024) until f.eof?
+          out <<  f.read(1024 * 1024) until f.eof?
         end
       end
 

--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -10,12 +10,10 @@ module Geminabox
       attr_accessor :file_handler
 
       def stream_file(file)
-        f = File.open(File.expand_path(File.join(Geminabox.data, *request.path_info)), "r")
-  
+        f = File.open(file, "r")
+
         stream do |out|
-          until f.eof?
-            out <<  f.read( 1024 * 1024 )
-          end
+          out <<  f.read(1024*1024) until f.eof?
         end
       end
 


### PR DESCRIPTION
I haven`t rised an issue, but I will explain here the reason of pull request.

I am moving my gemserver with geminabox from a vm to [Google Cloud Run](https://cloud.google.com/run) and using [Cloud Storage](https://cloud.google.com/storage) as gems storage to reduce running costs.  

In general it worked fine, but I faced an issue with [Google Cloud Run Quotas](https://cloud.google.com/run/quotas), Response could be not larger than 32 Mb. Its pretty rare that gem is larger than this limit, but still it exists, for example [wkhtmltopdf-binary-edge 0.12.4.0 (45.1 MB)](https://rubygems.org/gems/wkhtmltopdf-binary-edge) or [libv8-3.16.14.7-x86_64-darwin-14.gem (39 MB)](https://rubygems.org/gems/libv8/versions?page=4)
Cloud Run returns 500 and puts in log: `Response size was too large. Please consider reducing response size.`

Streaming solves the issue