### PR TITLE
chore(ci): add Ruby 3.2 to CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.3.8, 2.4.10, 2.5.9, 2.6.10, 2.7.6, 3.0.4, 3.1.2]
+        ruby-version: [2.3.8, 2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.6, 3.1.4, 3.2.2]
         gem-version: [3.3.15]
         include:
           - ruby-version: 2.3.8
@@ -34,7 +34,7 @@ jobs:
           - ruby-version: 2.6.10
             gem-version: 2.5.0
             continue-on-error: true
-          - ruby-version: 2.7.6
+          - ruby-version: 2.7.8
             gem-version: 2.5.0
             continue-on-error: true
 
@@ -57,12 +57,12 @@ jobs:
       run: bundle exec rake
       continue-on-error: ${{ matrix.continue-on-error }}
     - name: Workaround for coverage report to CodeClimate with jq
-      if: startsWith(matrix.ruby-version, '3.1')
+      if: startsWith(matrix.ruby-version, '3.2.')
       run: |
         jq 'map_values(. | map_values(if type=="object" then map_values(.lines) else . end))' coverage/.resultset.json > coverage/.resultset_workaround.json
         diff -uw coverage/.resultset.json coverage/.resultset_workaround.json || true
     - name: Send coverage report to CodeClimate
-      if: startsWith(matrix.ruby-version, '3.1')
+      if: startsWith(matrix.ruby-version, '3.2.')
       continue-on-error: true
       uses: paambaati/codeclimate-action@v4.0.0
       with:
@@ -77,7 +77,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1.148.0
       with:
-        ruby-version: 3.1.2
+        ruby-version: 3.2.2
     - name: Run RuboCop
       run: |
         bundle add rubocop --version 1.31.0


### PR DESCRIPTION
- Closes #510

Adds Ruby 3.2.2 to CI matrix, and also updates ruby 2.7, 3.0, and 3.1 to the latest revision of each.
