### PR TITLE
Add `rss` gem to fix undefined method `w3cdtf' for Time object

### DIFF
--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.require_paths     = ['lib']
 
   s.add_dependency('sinatra', "~> 2.0")
+  s.add_dependency('rss', "~> 0.2")
   s.add_dependency('builder')
   s.add_dependency('httpclient', [">= 2.2.7"])
   s.add_dependency('nesty')


### PR DESCRIPTION
```
 - - [25/May/2023:22:42:13 +0000] "GET /atom.xml HTTP/1.1" 500 239627 0.0919
 - - [25/May/2023:22:42:16 +0000] "GET /gems/nokogiri HTTP/1.1" 200 59517 0.0898
2023-05-25 22:42:16 - NoMethodError - undefined method `w3cdtf' for 2023-05-24 00:00:00 UTC:Time:
/usr/src/app/lib/../views/atom.erb:14:in `block in __tilt_432380'
```


# Proof of fix working 
```ruby
geminabox> Time.now.w3cdtf
=> "2023-06-09T08:17:40.777508-07:00"
```