### PR TITLE
Remove Unnecessary Dependency Constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 See https://github.com/geminabox/geminabox/releases.
 
+# 2.2.1
+ - Updated Sinatra dependency to v3.x
+
 # 1.4.2 - 1.5.0
 
 - https://github.com/geminabox/geminabox/releases/tag/v1.5.0

--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.files             = %w[MIT-LICENSE README.md] + Dir['{lib,public,views}/**/*']
   s.require_paths     = ['lib']
 
-  s.add_dependency('sinatra', "~> 2.0")
+  s.add_dependency('sinatra', ">= 3.0.0")
   s.add_dependency('builder')
   s.add_dependency('httpclient', [">= 2.2.7"])
   s.add_dependency('nesty')

--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -23,10 +23,10 @@ Gem::Specification.new do |s|
   s.files             = %w[MIT-LICENSE README.md] + Dir['{lib,public,views}/**/*']
   s.require_paths     = ['lib']
 
-  s.add_dependency('sinatra', ">= 3.0.0")
-  s.add_dependency('builder')
-  s.add_dependency('httpclient', [">= 2.2.7"])
-  s.add_dependency('nesty')
-  s.add_dependency('faraday', "> 1.0", "< 3.0")
-  s.add_dependency('reentrant_flock')
+  s.add_dependency 'sinatra'
+  s.add_dependency 'builder'
+  s.add_dependency 'httpclient'
+  s.add_dependency 'nesty'
+  s.add_dependency 'faraday'
+  s.add_dependency 'reentrant_flock'
 end

--- a/lib/geminabox/version.rb
+++ b/lib/geminabox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Geminabox
-  VERSION = '2.2.0.pre' unless defined? VERSION
+  VERSION = '2.2.1' unless defined? VERSION
 end


### PR DESCRIPTION
Fixes #553. The `gemspec` would actually be better if none of the dependencies had version information provided. It 'just works'. I have tested this successfully, so I updated my original PR.