### PR TITLE
Add support for rubygems 3.5+

### DIFF
--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_dependency('nesty')
   s.add_dependency('faraday', "> 1.0", "< 3.0")
   s.add_dependency('reentrant_flock')
+  s.add_dependency('rubygems-generate_index', "~> 1.1")
 end


### PR DESCRIPTION
'rubygems/indexer' is now shipped separately.

See https://github.com/rubygems/rubygems/pull/7085.

----

When rubygems 3.5 is installed (3.5.3 shipping with Ruby 3.3), the proposed change is enough to make `gem inabox` work again and avoid the following error:

```
> gem inabox
<internal:C:/Dev/Ruby33-x64/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require': cannot load such file -- rubygems/indexer (LoadError)
        from <internal:C:/Dev/Ruby33-x64/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
        from C:/Dev/Ruby33-x64/lib/ruby/gems/3.3.0/gems/geminabox-2.1.0/lib/geminabox.rb:8:in `<top (required)>'
```

Besides, installing `rubygems-generate_index` when a version of rubygems older than 3.5 is installed seems to be harmless, but I only did limited testing (Ruby 3.0.3, rubygems 3.4.7 and `gem inabox` used as a client, so it likely won't use the indexer itself).
