### PR TITLE
Deprecate the RubyGems proxy (3.1.0)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -455,7 +455,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 305
+  Max: 306
 
 # Offense count: 1
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+
+### Deprecated
+- **RubyGems proxy** (`RUBYGEMS_PROXY` env / `Geminabox.rubygems_proxy`) is
+  deprecated and **will be removed in 4.0.** It depends on the RubyGems.org
+  Dependency API (`/api/v1/dependencies`), which was
+  [sunset on 2023-05-24](https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html)
+  in favour of the Compact Index API, so proxy mode no longer functions.
+  Enabling it now emits a deprecation warning.
+
+### Internal
+- CI: `gem-push` workflow GitHub Actions pinned to commit SHAs. No
+  consumer-facing impact (not shipped in the gem).
+
 ## [3.0.0] - 2026-02-21
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [3.1.0] - 2026-06-02
 
 ### Deprecated
 - **RubyGems proxy** (`RUBYGEMS_PROXY` env / `Geminabox.rubygems_proxy`) is

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Start your gem server with 'rackup' to run WEBrick or hook up the config.ru as y
 
 ## RubyGems Proxy
 
+> **Deprecated.** The RubyGems proxy is unmaintained and **will be removed in
+> Geminabox 4.0.** It depends on the RubyGems.org Dependency API
+> (`/api/v1/dependencies`), which was [sunset on 2023-05-24](https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html)
+> in favour of the Compact Index API, so proxy mode no longer functions.
+> Enabling it now emits a deprecation warning. Do not rely on this feature.
+
 Geminabox can be configured to pull gems, it does not currently have, from rubygems.org. To enable this mode you can either:
 
 Set RUBYGEM_PROXY to true in the environment:

--- a/lib/geminabox.rb
+++ b/lib/geminabox.rb
@@ -68,6 +68,17 @@ module Geminabox
       Server.settings
     end
 
+    # Deprecated: the RubyGems proxy is unmaintained and will be removed in
+    # Geminabox 4.0. It depends on the RubyGems.org Dependency API
+    # (/api/v1/dependencies), which was sunset on 2023-05-24, so proxy mode no
+    # longer functions.
+    def warn_rubygems_proxy_deprecation
+      warn '[DEPRECATION] Geminabox RubyGems proxy is deprecated and will be ' \
+           'removed in Geminabox 4.0. It depends on the RubyGems.org ' \
+           'Dependency API (/api/v1/dependencies), which was sunset on ' \
+           '2023-05-24, so proxy mode no longer functions.'
+    end
+
     def call(env)
       Server.call env
     end

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -12,6 +12,7 @@ module Geminabox
     set :host_authorization, { permitted_hosts: [] }
 
     if Geminabox.rubygems_proxy
+      Geminabox.warn_rubygems_proxy_deprecation
       use Proxy::Hostess
     else
       use Hostess

--- a/lib/geminabox/version.rb
+++ b/lib/geminabox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Geminabox
-  VERSION = '3.0.0' unless defined? VERSION
+  VERSION = '3.1.0' unless defined? VERSION
 end


### PR DESCRIPTION
Deprecates the RubyGems proxy mode, slated for removal in 4.0. Cuts the **3.1.0** release.

## Why
The proxy depends on the RubyGems.org **Dependency API** (`/api/v1/dependencies`), which was [sunset on 2023-05-24](https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html) in favour of the Compact Index API — so proxy mode no longer functions. It also serves remote gems under the **same namespace** as locally hosted gems, a supply-chain hazard.

## What
- `Geminabox.warn_rubygems_proxy_deprecation` emits a `[DEPRECATION]` warning at boot when proxy mode is enabled (`RUBYGEMS_PROXY=true` / `Geminabox.rubygems_proxy = true`).
- README "RubyGems Proxy" section marked **Deprecated**.
- CHANGELOG `[3.1.0]` entry under **Deprecated**.
- Behaviour otherwise unchanged; all proxy code retained for the 3.x line.

Removal of the feature is a follow-up for 4.0.

## Verification
Full suite green (77 / 6 / 27, 0 failures); gem builds as `geminabox-3.1.0.gem`.