### PR TITLE
CI: pin gem-push actions to SHAs and bump ruby/setup-ruby to v1.310.0

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Ruby 3.1
-      uses: ruby/setup-ruby@a2bbe5b1b236842c1cb7dd11e8e3b51e0a616acc # v1.202.0
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: 3.1.2
 

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -13,9 +13,9 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Ruby 3.1
-      uses: ruby/setup-ruby@v1.202.0
+      uses: ruby/setup-ruby@a2bbe5b1b236842c1cb7dd11e8e3b51e0a616acc # v1.202.0
       with:
         ruby-version: 3.1.2
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
     - name: Set up Ruby
-      uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
@@ -44,7 +44,7 @@ jobs:
     steps:
     - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
     - name: Set up Ruby
-      uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: 3.2.10
     - name: Run RuboCop


### PR DESCRIPTION
Two related GitHub Actions hardening/maintenance changes.

1. **Pin actions to commit SHAs in `gem-push.yml`** — supply-chain hardening, matching the pinning already used in `ruby.yml`.
2. **Bump `ruby/setup-ruby` to v1.310.0** across all three usages (`gem-push.yml` + `ruby.yml` ×2), pinned to `afeafc3d1ab54a631816aba4c914a0081c12ff2f`.

### Supersedes #730
Dependabot PR #730 bumps `ruby/setup-ruby` 1.202.0 → 1.310.0 but predates the SHA-pinning above, so it (a) no longer applies cleanly to `gem-push.yml` and (b) would revert that line to a plain version tag. This PR achieves the same version bump while keeping everything SHA-pinned. #730 can be closed once this merges.