### PR TITLE
Content types on GET responses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -455,7 +455,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 306
+  Max: 312
 
 # Offense count: 1
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/geminabox.gemspec
+++ b/geminabox.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_dependency('faraday', "> 1.0", "< 3.0")
   s.add_dependency('reentrant_flock')
   s.add_dependency('rubygems-generate_index', '~> 1.1')
+  s.add_dependency('rss', '~> 0.3')
 end

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -91,6 +91,7 @@ module Geminabox
     end
 
     get '/' do
+      content_type :html
       @gems = load_gems
       @index_gems = index_gems(@gems)
       @allow_upload = self.class.allow_upload?
@@ -99,15 +100,18 @@ module Geminabox
     end
 
     get '/atom.xml' do
+      content_type 'application/atom+xml'
       @gems = load_gems
       erb :atom, :layout => false
     end
 
     get '/api/v1/dependencies' do
+      content_type 'application/octet-stream'
       query_gems.any? ? Marshal.dump(gem_list) : 200
     end
 
     get '/api/v1/dependencies.json' do
+      content_type :json
       query_gems.any? ? gem_list.to_json : {}
     end
 
@@ -116,6 +120,7 @@ module Geminabox
         error_response(403, 'Gem uploading is disabled')
       end
 
+      content_type :html
       erb :upload
     end
 
@@ -136,6 +141,7 @@ module Geminabox
       @gem = gems[params[:gemname]]
       @allow_delete = self.class.allow_delete?
       halt 404 unless @gem
+      content_type :html
       erb :gem
     end
 

--- a/lib/geminabox/server.rb
+++ b/lib/geminabox/server.rb
@@ -2,6 +2,7 @@
 
 require 'reentrant_flock'
 require 'rubygems/util'
+require 'rss'
 
 module Geminabox
 

--- a/test/requests/atom_feed_test.rb
+++ b/test/requests/atom_feed_test.rb
@@ -17,6 +17,7 @@ class AtomFeedTest < Minitest::Test
   test "atom feed returns when no gems are defined" do
     get "/atom.xml"
     assert last_response.ok?
+    assert_equal 'application/atom+xml', last_response.media_type
     refute_match %r{<entry>}, last_response.body
   end
 
@@ -27,6 +28,7 @@ class AtomFeedTest < Minitest::Test
 
     get "/atom.xml"
     assert last_response.ok?
+    assert_equal 'application/atom+xml', last_response.media_type
     feed_content = RSS::Parser.parse(last_response.body)
     feed_content.items.size == 1
   end

--- a/test/requests/content_type_test.rb
+++ b/test/requests/content_type_test.rb
@@ -1,0 +1,45 @@
+require_relative '../test_helper'
+require 'minitest'
+require 'rack/test'
+
+class ContentTypeTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def setup
+    clean_data_dir
+  end
+
+  def app
+    Geminabox::Server
+  end
+
+  test 'root page returns html content type' do
+    get '/'
+    assert last_response.ok?
+    assert_equal 'text/html', last_response.media_type
+  end
+
+  test 'upload page returns html content type' do
+    get '/upload'
+    assert last_response.ok?
+    assert_equal 'text/html', last_response.media_type
+  end
+
+  test 'atom feed returns atom content type' do
+    get '/atom.xml'
+    assert last_response.ok?
+    assert_equal 'application/atom+xml', last_response.media_type
+  end
+
+  test 'dependencies endpoint returns binary content type' do
+    get '/api/v1/dependencies'
+    assert last_response.ok?
+    assert_equal 'application/octet-stream', last_response.media_type
+  end
+
+  test 'dependencies json endpoint returns json content type' do
+    get '/api/v1/dependencies.json'
+    assert last_response.ok?
+    assert_equal 'application/json', last_response.media_type
+  end
+end

--- a/test/test_support/geminabox_test_case.rb
+++ b/test/test_support/geminabox_test_case.rb
@@ -10,6 +10,7 @@ require 'webrick/https'
 require 'logger'
 require 'rack/auth/abstract/handler'
 require 'rack/auth/abstract/request'
+require 'httpclient'
 
 class Geminabox::TestCase < Minitest::Test
   class << self
@@ -178,8 +179,29 @@ class Geminabox::TestCase < Minitest::Test
   end
 
   def assert_can_fetch(gemname = :example, *args)
-    geminabox_push(gem_file(gemname, *args))
+    gem_file_path = gem_file(gemname, *args)
+    geminabox_push(gem_file_path)
     assert_match( /Downloaded #{gemname}/, gem_fetch(gemname))
+    assert_gem_download_content_type(gem_file_path)
+  end
+
+  def assert_gem_download_content_type(gem_file_path)
+    gem_url = url_for("/gems/#{File.basename(gem_file_path)}")
+    response = http_client_for(gem_url).head(gem_url)
+    assert_equal 200, response.status
+    assert_equal 'application/octet-stream', response.headers['Content-Type']
+  end
+
+  def http_client_for(url)
+    uri = URI.parse(url)
+    HTTPClient.new.tap do |client|
+      if uri.user && uri.password
+        auth_url = uri.dup
+        auth_url.user = nil
+        auth_url.password = nil
+        client.set_auth(auth_url.to_s, uri.user, uri.password)
+      end
+    end
   end
 
   def assert_can_push(gemname = :example, *args)


### PR DESCRIPTION
## What

Explicitly set content types on responses to GET requests. These are;

* HTML for page rendering routes
* application/atom+xml for Atom feed routes
* application/json for JSON routes
* application/octet-stream on the marshaled dependencies route

New tests have been created to check this. Additionally, for completeness, the tests for fetching gems have been modified to also check the content type, which were already set correctly to application/octet-stream.

## Why

This is a bug fix for HTTP protocol correctness. I discovered this while working on a possibly new feature to allow GeinInABox to be embedded in another application.

## Why not

It is possible that this will cause a breaking change if clients depend on the content type always being HTML for all response types.

Additionally, the affected routes may be no longer relevant;

* api/v1/dependencies.json is slated for removal in the next version. ***Update:*** I see that this route is not being removed after all. I misunderstood #735 
* atom.xml has been broken for a while due to the removal of the rss gem from the Ruby core libraries. I have added a fix for this (copied from #546)

## Notes

I am not familiar with minitest as I mainly use RSpec so the modifications to the tests are strongly guided by Copilot, although I believe they look reasonable.