### PR TITLE
Add RuboCop dev dependency and CI wiring (curated from #737)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -47,9 +47,6 @@ jobs:
       uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: 3.2.10
+        bundler-cache: true
     - name: Run RuboCop
-      run: |
-        bundle add rubocop --version 1.55.0
-        bundle add rubocop-minitest --version 0.20.1
-        bundle add rubocop-rake --version 0.6.0
-        bundle exec rubocop
+      run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,21 @@ AllCops:
 Lint/NonAtomicFileOperation:
   Enabled: false
 
+# New cops from the rubocop 1.88 bump (#737). Not adopting them; disabling
+# rather than churning the codebase to comply.
+Naming/PredicateMethod:
+  Enabled: false
+Style/FileOpen:
+  Enabled: false
+Style/MapJoin:
+  Enabled: false
+Style/OneClassPerFile:
+  Enabled: false
+Style/PredicateWithKind:
+  Enabled: false
+Style/SuperWithArgsParentheses:
+  Enabled: false
+
 # The following is a workaround for disorder in rubocop auto-gen-config
 Layout/SpaceBeforeBlockBraces:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ gemspec
 
 group :development do
   gem 'byebug'
+  gem 'rubocop', '~> 1.88.0'
+  gem 'rubocop-minitest', '~> 0.20'
+  gem 'rubocop-rake', '~> 0.6'
 end
 group :test do
   if RUBY_VERSION >= '4.0'


### PR DESCRIPTION
Curated subset of #737 (thanks @jrmhaig). Takes the RuboCop dependency and CI wiring; defers the code-style changes.

## Included
- Add `rubocop`, `rubocop-minitest`, `rubocop-rake` to the `:development` group in the Gemfile.
- CI runs RuboCop from the bundle: drop the inline `bundle add` version pins and add `bundler-cache: true` to the rubocop job so the development-group gems install. The version source of truth moves from CI into the Gemfile.
- Pin `rubocop ~> 1.88`, up from the 1.55 CI installed inline.

## Deferred (visible backlog)
The 1.55 → 1.88 jump surfaces 6 new *pending* cops. Rather than churn lib/test code to comply now, they are disabled explicitly in `.rubocop.yml` as a backlog to work through later:

| Cop | Added in |
|---|---|
| Style/SuperWithArgsParentheses | 1.58 |
| Naming/PredicateMethod | 1.76 |
| Style/FileOpen | 1.85 |
| Style/MapJoin | 1.85 |
| Style/OneClassPerFile | 1.85 |
| Style/PredicateWithKind | 1.85 |

`AllCops: NewCops` stays `enable`, so future RuboCop bumps keep surfacing new cops for triage. `.rubocop_todo.yml` is untouched.

## Not included
The code auto-corrections from #737 (6 files under `lib/` and `test/`) are omitted, since none of the cops motivating them were adopted. No production or test code changes here.

## Verification
- `bundle exec rubocop` → 0 offenses
- `bundle exec rake test` → 77 + 6 + 27 tests, 0 failures, 0 errors
