### PR TITLE
Honor closed and suffix byte ranges on the compact index

### DIFF
--- a/lib/geminabox/compact_index_api.rb
+++ b/lib/geminabox/compact_index_api.rb
@@ -6,8 +6,10 @@ module Geminabox
   # Sinatra helpers implementing the compact index HTTP semantics:
   # - ETag is the quoted MD5 of the full body (Bundler <= 2.4 verifies
   #   exactly that after reassembling ranged fetches).
-  # - Only the open-ended range form Bundler sends (bytes=N-) is honored;
-  #   anything else gets a full 200, which clients must tolerate.
+  # - A single byte range is honored in all three forms (bytes=N-, bytes=N-M,
+  #   bytes=-N); Bundler only ever sends the open-ended tail. Multipart,
+  #   malformed, and unsatisfiable ranges get a full 200 rather than a 416,
+  #   which clients must tolerate (RFC 9110 permits ignoring Range).
   # - Repr-Digest/Digest carry sha-256 of the FULL file even on 206 —
   #   without them Bundler >= 2.5 refuses to append partial responses.
   #
@@ -26,12 +28,12 @@ module Geminabox
               "Cache-Control" => "max-age=60"
       content_type "text/plain; charset=utf-8"
       halt 304 if request.env["HTTP_IF_NONE_MATCH"] == etag
-      first_byte = range_start(request.env["HTTP_RANGE"], contents.bytesize)
-      if first_byte
+      range = byte_range(request.env["HTTP_RANGE"], contents.bytesize)
+      if range
         status 206
         headers "Content-Range" =>
-          "bytes #{first_byte}-#{contents.bytesize - 1}/#{contents.bytesize}"
-        contents.byteslice(first_byte..)
+          "bytes #{range.begin}-#{range.end}/#{contents.bytesize}"
+        contents.byteslice(range)
       else
         contents
       end
@@ -39,12 +41,29 @@ module Geminabox
 
     private
 
-    def range_start(header, size)
-      match = /\Abytes=(\d+)-\z/.match(header.to_s)
-      return unless match
+    # Inclusive byte range to serve, or nil to serve the whole body.
+    def byte_range(header, size)
+      match = /\Abytes=(\d*)-(\d*)\z/.match(header.to_s)
+      return if match.nil? || size.zero?
 
-      first_byte = Integer(match[1])
-      first_byte < size ? first_byte : nil
+      first, last = match.captures
+      return suffix_range(last, size) if first.empty?
+
+      first_byte = Integer(first)
+      return if first_byte >= size
+
+      last_byte = last.empty? ? size - 1 : [Integer(last), size - 1].min
+      first_byte..last_byte unless last_byte < first_byte
+    end
+
+    # bytes=-N asks for the final N bytes; N == 0 is unsatisfiable.
+    def suffix_range(last, size)
+      return if last.empty?
+
+      length = Integer(last)
+      return if length.zero?
+
+      [size - length, 0].max..(size - 1)
     end
 
     def compact_file_digests(path, stat, contents)

--- a/test/requests/compact_index_test.rb
+++ b/test/requests/compact_index_test.rb
@@ -67,6 +67,84 @@ class CompactIndexTest < Minitest::Test
     assert_equal size, last_response.body.bytesize
   end
 
+  test "GET /versions serves a closed range" do
+    get "/versions"
+    full = last_response.body
+    get "/versions", {}, { "HTTP_RANGE" => "bytes=10-20" }
+    assert_equal 206, last_response.status
+    assert_equal full.byteslice(10..20), last_response.body
+    assert_equal "bytes 10-20/#{full.bytesize}",
+                 last_response.headers["Content-Range"]
+  end
+
+  test "GET /versions clamps a closed range that runs past EOF" do
+    get "/versions"
+    full = last_response.body
+    last = full.bytesize - 1
+    get "/versions", {}, { "HTTP_RANGE" => "bytes=10-#{full.bytesize + 500}" }
+    assert_equal 206, last_response.status
+    assert_equal full.byteslice(10..last), last_response.body
+    assert_equal "bytes 10-#{last}/#{full.bytesize}",
+                 last_response.headers["Content-Range"]
+  end
+
+  test "GET /versions serves a suffix range" do
+    get "/versions"
+    full = last_response.body
+    size = full.bytesize
+    get "/versions", {}, { "HTTP_RANGE" => "bytes=-10" }
+    assert_equal 206, last_response.status
+    assert_equal full.byteslice(size - 10, 10), last_response.body
+    assert_equal "bytes #{size - 10}-#{size - 1}/#{size}",
+                 last_response.headers["Content-Range"]
+  end
+
+  test "GET /versions serves the whole file for an oversized suffix range" do
+    get "/versions"
+    full = last_response.body
+    get "/versions", {}, { "HTTP_RANGE" => "bytes=-#{full.bytesize + 500}" }
+    assert_equal 206, last_response.status
+    assert_equal full, last_response.body
+    assert_equal "bytes 0-#{full.bytesize - 1}/#{full.bytesize}",
+                 last_response.headers["Content-Range"]
+  end
+
+  test "GET /versions ignores a zero-length suffix range" do
+    get "/versions"
+    full = last_response.body
+    get "/versions", {}, { "HTTP_RANGE" => "bytes=-0" }
+    assert_equal 200, last_response.status
+    assert_equal full, last_response.body
+  end
+
+  test "GET /versions ignores an inverted range" do
+    get "/versions"
+    full = last_response.body
+    get "/versions", {}, { "HTTP_RANGE" => "bytes=20-10" }
+    assert_equal 200, last_response.status
+    assert_equal full, last_response.body
+  end
+
+  test "GET /versions ignores a multipart range" do
+    get "/versions"
+    full = last_response.body
+    get "/versions", {}, { "HTTP_RANGE" => "bytes=0-5,10-15" }
+    assert_equal 200, last_response.status
+    assert_equal full, last_response.body
+    assert_nil last_response.headers["Content-Range"]
+  end
+
+  test "GET /info/GEMNAME serves a closed range" do
+    get "/versions"
+    get "/info/a"
+    full = last_response.body
+    get "/info/a", {}, { "HTTP_RANGE" => "bytes=5-15" }
+    assert_equal 206, last_response.status
+    assert_equal full.byteslice(5..15), last_response.body
+    assert_equal "bytes 5-15/#{full.bytesize}",
+                 last_response.headers["Content-Range"]
+  end
+
   test "GET /info/GEMNAME serves the info file" do
     get "/versions"
     get "/info/a"


### PR DESCRIPTION
`serve_compact_file` only honored the open-ended `bytes=N-` form that Bundler
sends. Closed (`bytes=a-b`) and suffix (`bytes=-N`) ranges fell through to a
full 200 while the response still advertised `Accept-Ranges: bytes`.

RFC 9110 §14.2 permits a server to ignore `Range`, so this was never a protocol
violation, and Bundler's incremental tail-append was already working — asserted
end to end against a real Bundler over Puma in
`test/integration/compact_index/compact_index_test.rb:28` and `:125`. The
advertisement just did not match the behavior, which invites bug reports.

## Change

`byte_range` replaces `range_start`. It resolves all three single-range forms to
an inclusive range and clamps a closed range at EOF:

```
bytes=100-200  ->  206  bytes 100-118/119   (was 200, full body)
bytes=-50      ->  206  bytes  69-118/119   (was 200, full body)
bytes=100-     ->  206  bytes 100-118/119   (unchanged)
```

Multipart (`bytes=0-5,10-15`), inverted, zero-length-suffix, and unsatisfiable
ranges still return a full 200 rather than a 416. Bundler recovers from a full
body, where a 416 risks breaking it. The existing "ignores an unsatisfiable
range" test passes unchanged.

`Repr-Digest`/`Digest` continue to describe the full file on a 206, and the 304
branch is still evaluated before any range handling.

## Tests

Nine new request tests in `test/requests/compact_index_test.rb`, written first
and watched fail — five failed with "expected 206, got 200"; the three
ignore-cases passed immediately, confirming that behavior was already correct.

47 unit/request tests and 35 integration tests pass. Rubocop clean.
